### PR TITLE
Add github action to add new issues to Icebox

### DIFF
--- a/.github/workflows/new-issues-to-icebox.yml
+++ b/.github/workflows/new-issues-to-icebox.yml
@@ -1,0 +1,15 @@
+name: Add new issues to the Icebox
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.3.0
+        with:
+          project: operations-engineering
+          column: Icebox
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This github action will create a new card for every issue opened, and
add it to the "Icebox" column of the "operations-engineering" project.

More information about this github action can be found here:
https://github.com/alex-page/github-project-automation-plus

fixes #45
