### PR TITLE
Use bot user PAT for issue automation

### DIFF
--- a/.github/workflows/new-issues-to-icebox.yml
+++ b/.github/workflows/new-issues-to-icebox.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: operations-engineering
           column: Icebox
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.CLOUD_PLATFORM_MOJ_GITHUB_TOKEN }}


### PR DESCRIPTION
This action was failing with 
```
Resource not accessible by integration
```
I think this relates to [this issue](https://github.com/alex-page/github-project-automation-plus/issues/51) so I'm replacing the default, automatically-provided `GITHUB_TOKEN` secret with a personal access token (PAC) belonging to the `cloud-platform-moj github bot account (which I have added to the `operations-engineering` github team).

This token has `repo` scope, and has been enabled for MoJ SSO, and added to this repo as the secret `CLOUD_PLATFORM_MOJ_GITHUB_TOKEN`

I'm hoping this will enable this action to work as it's supposed to.