### PR TITLE
Use hard-coded page title to fix publish process

### DIFF
--- a/source/documentation/index.html.md.erb
+++ b/source/documentation/index.html.md.erb
@@ -3,5 +3,5 @@ last_reviewed_on: 2020-10-21
 review_in: 3 months
 ---
 
-# <%= current_page.data.title %>
+# MoJ Operations Engineering
 


### PR DESCRIPTION
Although the `current_page.data.title` works fine in preview mode, it
causes errors when the site is published.

This change should fix that, and allow the publishing process to
succeed.

related to #37
