### PR TITLE
Add initial structure and content

### DIFF
--- a/source/documentation/adrs.html.md.erb
+++ b/source/documentation/adrs.html.md.erb
@@ -1,0 +1,23 @@
+---
+title: Architecture Decision Records
+last_reviewed_on: 2020-12-01
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+This is a record of architectural decisions made by the Operations Engineering Team
+
+To understand why we are recording decisions and how we are doing it, please see ADR-000
+
+| Status | ADR no. | Title |
+| :-- | :-- | :-- |
+| ✅ | ADR-000 | [Record Architecture Decisions](adrs/adr-000.html) |
+
+### Statuses:
+
+* 🤔 Proposed
+* ✅ Accepted
+* ❌ Rejected
+* ⌛️ Superseded
+* ♻️  Amended

--- a/source/documentation/adrs/adr-000.html.md.erb
+++ b/source/documentation/adrs/adr-000.html.md.erb
@@ -1,0 +1,94 @@
+---
+title: ADR-000 Record Architecture Decisions
+last_reviewed_on: 2020-12-01
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+### Date: 2020-12-01
+
+## Status
+
+✅ Accepted
+
+## Context
+
+During our work on the Operations Engineering Team, we will have to make
+architectural decisions about tools & processes.
+
+When making decisions, we should record them somewhere for future reference, to
+help us remember why we made them, and to help teams working in related areas
+understand why we made them.
+
+We should make our decisions public so that other teams can find them more
+easily, and because [making things open makes things
+better](https://www.gov.uk/guidance/government-design-principles#make-things-open-it-makes-things-better).
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in
+[this
+article](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+
+An architecture decision record is a short text file describing a single
+decision.
+
+We will keep ADRs in this public repository under `adrs/adr-[number].html.md.erb`
+
+ADRs will be numbered sequentially and monotonically. Numbers will not be
+reused.
+
+If a decision is reversed, we will keep the old one around, but mark it as
+superseded. (It's still relevant to know that it was the decision, but is no
+longer the decision.)
+
+We will use a format with just a few parts, so each document is easy to digest:
+
+**Title** These documents have names that are short noun phrases. For example,
+"ADR-000: Record architectural decisions" or "ADR-009: Use Docker for deployment"
+
+**Status** A decision may be "proposed" if it's still under discussion, or
+"accepted" once it is agreed. If a later ADR changes or reverses a decision, it
+may be marked as "superseded" with a reference to its replacement.
+
+**Context** This section describes the forces at play, including technological,
+political, social, and local to the service. These forces are probably in
+tension, and should be called out as such. The language in this section is
+value-neutral. It is simply describing facts.
+
+**Decision** This section describes our response to these forces. It is stated
+in full sentences, with active voice. "We will ..."
+
+**Consequences** This section describes the resulting context, after applying
+the decision. All consequences should be listed here, not just the "positive"
+ones. A particular decision may have positive, negative, and neutral
+consequences, but all of them affect the team and service in the future.
+
+The whole document should be one or two pages long. We will write each ADR as
+if it is a conversation with a future person joining the team. This requires
+good writing style, with full sentences organised into paragraphs. Bullets are
+acceptable only for visual style, not as an excuse for writing sentence
+fragments.
+
+[adr-tools](https://github.com/npryce/adr-tools) can help us work with our ADRs
+consistently.
+
+We will link to these ADRs from other documentation where relevant.
+
+## Consequences
+
+One ADR describes one significant decision for the service. It should be
+something that has an effect on how the rest of the service will run.
+
+Developers and service stakeholders (and anyone else who's interested) can see
+the ADRs, even as the team composition changes over time.
+
+The motivation behind previous decisions is visible for everyone, present and
+future. Nobody is left scratching their heads to understand, "What were they
+thinking?" and the time to change old decisions will be clear from changes in
+the service's context.
+
+Having a central place to record decisions which affect all of our work will
+make the sequence of decisions clear, and make it easier for us to refer back to
+decisions later on.

--- a/source/documentation/index.html.md.erb
+++ b/source/documentation/index.html.md.erb
@@ -1,7 +1,0 @@
----
-last_reviewed_on: 2020-10-21
-review_in: 3 months
----
-
-# MoJ Operations Engineering
-

--- a/source/documentation/runbooks.html.md.erb
+++ b/source/documentation/runbooks.html.md.erb
@@ -1,0 +1,9 @@
+---
+title: Runbooks
+last_reviewed_on: 2020-12-01
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+* [Add a runbook](runbooks/add-a-runbook.html)

--- a/source/documentation/runbooks/add-a-runbook.html.md.erb
+++ b/source/documentation/runbooks/add-a-runbook.html.md.erb
@@ -1,0 +1,16 @@
+---
+title: Add a runbook
+last_reviewed_on: 2020-12-01
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+To add a new runbook:
+
+* Create a new `*.html.md.erb` file in the `source/documentation/runbooks` directory of this repository, containing the runbook information
+* Add a corresponding list item in the `source/documentation/runbooks.html.md.erb` file
+
+> The link target should be `runbooks/[filename].html` i.e. if the runbook file is `source/documentation/runbooks/foobar.html.md.erb` then the link target should be `runbooks/foobar.html`
+
+* Raise and merge a PR to add your changes to the `main` branch of this repository

--- a/source/documentation/services.html.md.erb
+++ b/source/documentation/services.html.md.erb
@@ -1,0 +1,38 @@
+---
+title: Our Services
+last_reviewed_on: 2020-12-01
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+The Operations Engineering team maintains the following:
+
+## Services
+
+* [Pingdom](https://pingdom.com)
+* [PagerDuty](https://pagerduty.com)
+* [CircleCI](https://circleci.com)
+* [LastPass](https://lastpass.com)
+* [Sentry.io](https://sentry.io)
+* OS Places - TBD
+* SSL Certificate Management - TBD
+
+## Tools
+
+* [Shared github actions](https://github.com/ministryofjustice/github-actions)
+* [MoJ DNS](https://github.com/ministryofjustice/dns)
+* [MoJ IP Addresses](https://github.com/ministryofjustice/moj-ip-addresses)
+* [Ministry of Justice Acronyms](https://ministryofjustice.github.io/acronyms/)
+* [MoJ GitHub Repository Template](https://github.com/ministryofjustice/template-repository)
+* [Template Documentation Site](https://github.com/ministryofjustice/template-documentation-site)
+* [Github external collaborators](https://github.com/ministryofjustice/operations-engineering-github-collaborators)
+* Register of Tech/BizOps - TBD
+* Maintenance pages as a service - TBD
+* Domain Management - TBD
+* AWS Account Management - TBD
+
+## Standards
+
+* Runbook Standards - TBD
+* Github Standards - TBD

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -4,7 +4,7 @@ last_reviewed_on: 2020-11-23
 review_in: 3 months
 ---
 
-<%= partial 'documentation/index' %>
+# <%= current_page.data.title %>
 
 ## Our vision
 
@@ -24,32 +24,14 @@ Our primary contact channel is #ask-operations-engineering. Please use this chan
 
 You can also send email to: operations-engineering@digital.justice.gov.uk
 
-## Our Services
+## [Our Services](documentation/services.html)
 
-The Operations Engineering team maintains the following shared services and resources:
+A list of the tools and services managed by the Operations Engineering Team.
 
-* [Shared github actions](https://github.com/ministryofjustice/github-actions)
-* [MoJ DNS](https://github.com/ministryofjustice/dns)
-* [MoJ IP Addresses](https://github.com/ministryofjustice/moj-ip-addresses)
-* [Ministry of Justice Acronyms](https://ministryofjustice.github.io/acronyms/)
-* [MoJ GitHub Repository Template](https://github.com/ministryofjustice/template-repository)
-* [Template Documentation Site](https://github.com/ministryofjustice/template-documentation-site)
-* [Pingdom](https://pingdom.com)
-* [PagerDuty](https://pagerduty.com)
-* [CircleCI](https://circleci.com)
-* [LastPass](https://lastpass.com)
-* [Sentry.io](https://sentry.io)
-* [Github external collaborators](https://github.com/ministryofjustice/operations-engineering-github-collaborators)
-* Github Standards - TBD
-* OS Places - TBD
-* SSL Certificate Management - TBD
-* Register of Tech/BizOps - TBD
-* Runbook Standards - TBD
-* Maintenance pages as a service - TBD
-* Domain Management - TBD
-* AWS Account Management - TBD
+## [Runbooks](documentation/runbooks.html)
 
-## Architecture Decision Records
+Documents detailing various processes that members of the Operations Engineering Team, or our users, need to carry out.
 
-TBD
+## [Architecture Decision Records](documentation/adrs.html)
 
+A record of the technical decisions made by the team.


### PR DESCRIPTION
* Add pages for ADRs, Services, Runbooks
* Add first runbook & ADR
* Rearrange Services content

You can see a copy of this site with these changes
merged [here](https://digitalronin.github.io/operations-engineering/#moj-operations-engineering)