### PR TITLE
Update github collaborators link

### DIFF
--- a/source/documentation/services.html.md.erb
+++ b/source/documentation/services.html.md.erb
@@ -26,7 +26,7 @@ The Operations Engineering team maintains the following:
 * [Ministry of Justice Acronyms](https://ministryofjustice.github.io/acronyms/)
 * [MoJ GitHub Repository Template](https://github.com/ministryofjustice/template-repository)
 * [Template Documentation Site](https://github.com/ministryofjustice/template-documentation-site)
-* [Github external collaborators](https://github.com/ministryofjustice/operations-engineering-github-collaborators)
+* [Github external collaborators](https://github.com/ministryofjustice/github-collaborators)
 * Register of Tech/BizOps - TBD
 * Maintenance pages as a service - TBD
 * Domain Management - TBD


### PR DESCRIPTION
The repo has been renamed from `operations-engineering-github-collaborators` to `github-collaborators`