### PR TITLE
Fix header block

### DIFF
--- a/source/documentation/runbooks/manual-ssl-certificate-processes.html.md.erb
+++ b/source/documentation/runbooks/manual-ssl-certificate-processes.html.md.erb
@@ -1,3 +1,4 @@
+---
 title: Create Manual SSL Certificate Processes
 last_reviewed_on: 2020-12-07
 review_in: 3 months


### PR DESCRIPTION
The metadata block was missing its opening `---` which makes middleman
throw an error when it tries to build this page.
