### PR TITLE
Replace LastPass link

### DIFF
--- a/source/documentation/services.html.md.erb
+++ b/source/documentation/services.html.md.erb
@@ -13,7 +13,7 @@ The Operations Engineering team maintains the following:
 * [Pingdom](https://pingdom.com)
 * [PagerDuty](https://pagerduty.com)
 * [CircleCI](https://circleci.com)
-* [LastPass](https://lastpass.com)
+* [LastPass](https://ministryofjustice.github.io/security-guidance/using-lastpass/#using-lastpass-enterprise)
 * [Sentry.io](https://sentry.io)
 * OS Places - TBD
 * SSL Certificate Management - TBD


### PR DESCRIPTION
Replacing link for LastPass.com with a link to Ministry of Justice security guidance and process