### PR TITLE
Rename OS API link

### DIFF
--- a/source/documentation/services.html.md.erb
+++ b/source/documentation/services.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Our Services
-last_reviewed_on: 2021-02-23
+last_reviewed_on: 2021-03-19
 review_in: 3 months
 ---
 
@@ -15,7 +15,7 @@ The Operations Engineering team maintains the following:
 * [CircleCI](https://circleci.com)
 * [LastPass](https://ministryofjustice.github.io/security-guidance/using-lastpass/#using-lastpass-enterprise)
 * [Sentry.io](services/sentry.html)
-* [OS Places](services/os-places.html)
+* [OS Date Hub APIs](services/os-places.html)
 * [SSL Certificate Management](services/SSL-certificate-management.html)
 * [Domain Management](services/domain-management.html)
 


### PR DESCRIPTION
We no longer just offer Places API keys. Name changed to reflect new OS service