### PR TITLE
Add use cases for all services

### DIFF
--- a/source/documentation/services.html.md.erb
+++ b/source/documentation/services.html.md.erb
@@ -10,16 +10,18 @@ The Operations Engineering team maintains the following:
 
 ## Services
 
-* [Pingdom](https://pingdom.com)
-* [PagerDuty](https://pagerduty.com)
-* [CircleCI](https://circleci.com)
-* [LastPass](https://ministryofjustice.github.io/security-guidance/using-lastpass/#using-lastpass-enterprise)
-* [Sentry.io](services/sentry.html)
-* [OS Date Hub APIs](services/os-places.html)
-* [SSL Certificate Management](services/SSL-certificate-management.html)
-* [Domain Management](services/domain-management.html)
-* [MoJ Heroku Account](https://id.heroku.com/login)
-* [MoJ Dockerhub Account](services/dockerhub.html)
+| Service | Use for |
+| --- | --- |
+| [Pingdom](https://pingdom.com) | uptime monitoring |
+| [PagerDuty](https://pagerduty.com) | incident management |
+| [CircleCI](https://circleci.com) | continuous integration |
+| [LastPass](https://ministryofjustice.github.io/security-guidance/using-lastpass/#using-lastpass-enterprise) | password sharing |
+| [Sentry.io](services/sentry.html) | exception monitoring, APM |
+| [OS Date Hub APIs](services/os-places.html) | frequently used API |
+| [SSL Certificate Management](services/SSL-certificate-management.html) | certificates |
+| [Domain Management](services/domain-management.html) | domain |
+| [MoJ Heroku Account](https://id.heroku.com/login) | hosting |
+| [MoJ Dockerhub Account](services/dockerhub.html) | container registry |
 
 ## Tools
 


### PR DESCRIPTION
To help people trying to look for a solution -- it might not be a good place _here_, though

Context: I thought about this because for APM, HMPPS uses Azure AppInsights and I was wondering if alternatives can be suggested here later on

----

This change renders like this:

<img width="933" alt="image" src="https://user-images.githubusercontent.com/1526295/132509371-64eb7f1b-b3c0-4dd8-8993-8a82f98b8183.png">
