### PR TITLE
Add *.cjscp.org.uk domain exceptions

### DIFF
--- a/source/documentation/runbooks/manual-ssl-certificate-processes.html.md.erb
+++ b/source/documentation/runbooks/manual-ssl-certificate-processes.html.md.erb
@@ -49,7 +49,7 @@ Please contact your [administrator](mailto:certificates@digital.justice.gov.uk) 
 
 We will review the list of Gandi.net certificates and identify any that require renewal 4 weeks prior to expiry (we also get a notification to Certificate Alerts 29 and 14 days prior to expiry).
 
-**Note that we are not responsible for any HMCTS owned certficates. These are typically domains in the format `<application>.<environment>.hmcts.net`. For these no action is required. The contact for these certficates is [opsconfman@hmcts.net](mailto:opsconfman@hmcts.net). That Team has access to all the shared mailboxs and gets all the same notifications for renewals.**
+**Note that we are not responsible for any HMCTS owned certficates. These are typically domains in the format `<application>.<environment>.hmcts.net` or `<application>.<environment>.cjscp.org.uk`. For these no action is required. The contact for these certficates is [opsconfman@hmcts.net](mailto:opsconfman@hmcts.net). That Team has access to all the shared mailboxs and gets all the same notifications for renewals.**
 
 1. Contact the service owner to confirm if renewal is required. If not, allow the certificate to expire. Detail of owners can be found by searching the [certificates@digital.justice.gov.uk Google Group](https://groups.google.com/a/digital.justice.gov.uk/g/certificates?hl=en-GB).
 

--- a/source/documentation/runbooks/manual-ssl-certificate-processes.html.md.erb
+++ b/source/documentation/runbooks/manual-ssl-certificate-processes.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Create Manual SSL Certificate Processes
-last_reviewed_on: 2021-09-27
+last_reviewed_on: 2021-11-10
 review_in: 3 months
 ---
 


### PR DESCRIPTION
Domains of the format *.cjscp.org.uk are also owned by HMCTS so do not require renewal by Operations Engineering