### PR TITLE
Remove link to Heroku

### DIFF
--- a/source/documentation/services.html.md.erb
+++ b/source/documentation/services.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Our Services
-last_reviewed_on: 2022-05-27
+last_reviewed_on: 2022-06-30
 review_in: 3 months
 ---
 
@@ -21,7 +21,6 @@ The Operations Engineering team maintains the following:
 | [OS Date Hub APIs](services/os-places.html) | API for postcode lookup, postcode verification and other mapping services|
 | [SSL Certificate Management](services/SSL-certificate-management.html) | certificates |
 | [Domain Management](services/domain-management.html) | domain |
-| [MoJ Heroku Account](https://id.heroku.com/login) | hosting (non-strategic) |
 | [MoJ Dockerhub Account](services/dockerhub.html) | container registry |
 | [MoJ Auth0 Account](https://auth0.com/) | authentication |
 | [SonarCloud](https://sonarcloud.io/) | code testing |


### PR DESCRIPTION
Remove link to Heroku as service is no longer used/supported.