### PR TITLE
Stop using the GOV.UK logo and crown in the header

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,7 +4,7 @@
 host: https://ministryofjustice.github.io/operations-engineering
 
 # Header-related options
-show_govuk_logo: true
+show_govuk_logo: false
 service_name: MoJ Operations Engineering
 service_link: /#moj-operations-engineering
 


### PR DESCRIPTION
We shouldn't be using these on this site as it's not part of GOV.UK:

https://www.gov.uk/service-manual/design/making-your-service-look-like-govuk#if-your-service-isnt-on-govuk

We also shouldn't be using the New Transport font, but it's harder to change
that as the govuk_tech_docs gem doesn't have a setting for it:

https://github.com/alphagov/tech-docs-gem/issues/138