### PR TITLE
Add github action to move dependabot tickets to Refined and Ready

### DIFF
--- a/.github/workflows/move-dependabot-issues.yml
+++ b/.github/workflows/move-dependabot-issues.yml
@@ -1,0 +1,25 @@
+name: Move all dependabot issues to "Refined and Ready"
+on:
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: python3 -m pip install -r python/requirements.txt
+      - run: python3 -m python.scripts.move_dependabot_tickets --api_token ${{ secrets.ZENHUB_API_KEY }}
+        env:
+          ZENHUB_API_KEY: ${{ secrets.ZENHUB_API_KEY }}
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Overview
---

This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/2153 and https://github.com/ministryofjustice/operations-engineering/pull/2288 which creates a way for operations-engineering to automate moving tickets dependant on their label. In this instance all we have to do is run the script and allow the default values to do the rest.

What does this PR do
---

By adding this github action, any dependabot PRs will be moved the 'Refined and Ready' "pipeline" in Zenhub. Initially, this should be on manual trigger, but will eventually lead to cron driven.
