### PR TITLE
Add cron schedule to Zenhub trigger every 12 hours

### DIFF
--- a/.github/workflows/move-dependabot-issues.yml
+++ b/.github/workflows/move-dependabot-issues.yml
@@ -1,6 +1,8 @@
 name: Move all dependabot issues to "Refined and Ready"
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "* */12 * * 1-5" # Every 12 hours, Monday through Friday
 
 jobs:
   run-script:


### PR DESCRIPTION
This PR closes https://github.com/ministryofjustice/operations-engineering/issues/2153 and automates the 'zenhub issue move' github action trigger. It should allow the action to trigger once every 12 hours Monday to Friday.