### PR TITLE
Don't trigger formatter on draft PRs

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,12 +1,13 @@
-name: code-formatter
+name: Format code
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:
   format-code:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v3
       - uses: ministryofjustice/github-actions/code-formatter@v11


### PR DESCRIPTION
If a PR is in draft i.e. a work in progress, we don't want a commit to tell us the code is incorrectly formatted. When moved to 'Ready for Review', the check should then trigger and perform the necessary changes.
