### PR TITLE
Refactor support assignment script

### DIFF
--- a/python/scripts/assign_support_tickets.py
+++ b/python/scripts/assign_support_tickets.py
@@ -46,7 +46,13 @@ def main():
     )
 
     gh = GithubService(args.oauth_token, args.org)
-    issues = gh.assign_support_issues_to_self(args.repo, args.org, args.tag)
+
+    try:
+        issues = gh.assign_support_issues_to_self(args.repo, args.org, args.tag)
+    except ValueError as error:
+        logging.error(f"Failed to assign issues: {error}")
+        raise error
+    
     if not issues:
         logging.warning("No issues found, skipping")
     for issue in issues:

--- a/python/scripts/assign_support_tickets.py
+++ b/python/scripts/assign_support_tickets.py
@@ -48,15 +48,17 @@ def main():
     gh = GithubService(args.oauth_token, args.org)
 
     try:
-        issues = gh.assign_support_issues_to_self(args.repo, args.org, args.tag)
+        issues = gh.assign_support_issues_to_self(
+            args.repo, args.org, args.tag)
     except ValueError as error:
         logging.error(f"Failed to assign issues: {error}")
         raise error
-    
+
     if not issues:
         logging.warning("No issues found, skipping")
     for issue in issues:
-        logging.info(f"Assigned issue {issue.number} to {issue.assignee.login}")
+        logging.info(
+            f"Assigned issue {issue.number} to {issue.assignee.login}")
 
 
 if __name__ == "__main__":

--- a/python/services/github_service.py
+++ b/python/services/github_service.py
@@ -84,6 +84,37 @@ class GithubService:
                 and issue.state == "open"
                 and grace_period < datetime.now())
 
+    def assign_support_issues_to_self(self, repository_name, org_name, tag: str) -> list[any]:
+        """
+            Assigns issues with a specific tag to the user who created the issue.
+            This is used to assign support issues to the user who created the issue.
+
+            :param repository_name: The name of the repository to assign issues in.
+            :param org_name: The name of the organisation to assign issues in.
+            :param tag: The tag to search for.
+        """
+        support_issues = [
+            issue
+            for issue in self.__get_open_issues_from_repo(f"{org_name}/{repository_name}")
+            for label in issue.labels
+            if label.name == tag and len(issue.assignees) == 0
+        ]
+
+        for issue in support_issues:
+            issue.edit(assignees=[issue.user.login])
+            if issue.user.login != issue.assignees[0].login:
+                raise ValueError(
+                    f"Failed to assign issue {issue.number} to {issue.user.login} in {repository_name}")
+
+        return support_issues
+
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def __get_open_issues_from_repo(self, repository_name: str) -> list[Issue]:
+        required_state = "open"
+        repo = self.github_client_core_api.get_repo(repository_name)
+
+        return repo.get_issues(state=required_state) or []
+
     @retries_github_rate_limit_exception_at_next_reset_once
     def create_an_access_removed_issue_for_user_in_repository(self, user_name: str, repository_name: str) -> None:
         logging.info(

--- a/python/services/github_service.py
+++ b/python/services/github_service.py
@@ -99,7 +99,8 @@ class GithubService:
         try:
             return self.assign_issues_to_self(support_issues, name)
         except ValueError as error:
-            raise error
+            raise ValueError(
+                f"Failed to assign issues to self in {repository_name}") from error
 
     @staticmethod
     def assign_issues_to_self(issues: list[Issue], repository_name: str) -> list[any]:

--- a/python/test/test_assign_support_tickets.py
+++ b/python/test/test_assign_support_tickets.py
@@ -5,6 +5,8 @@ import python.scripts.assign_support_tickets as assign_support_tickets
 
 
 @patch("github.Github.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 class TestAssignSupportTicket(unittest.TestCase):
 
     @patch("sys.argv", [
@@ -17,9 +19,7 @@ class TestAssignSupportTicket(unittest.TestCase):
         "fake",
     ])
     def test_call_main_with_arguments(self):
-        with patch("python.services.github_service.GithubService.assign_support_issues_to_self") as mock:
-            mock.return_value = []
-            assign_support_tickets.main()
+        assign_support_tickets.main()
 
     @patch("sys.argv", ["", "--oauth-token"])
     def test_call_main_without_arguments(self):

--- a/python/test/test_assign_support_tickets.py
+++ b/python/test/test_assign_support_tickets.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import python.scripts.assign_support_tickets as assign_support_tickets
+
+
+@patch("github.Github.__new__", new=MagicMock)
+class TestAssignSupportTicket(unittest.TestCase):
+
+    @patch("sys.argv", [
+        "",
+        "--oauth-token",
+        "fake",
+        "--org",
+        "fake",
+        "--repo",
+        "fake",
+    ])
+    def test_call_main_with_arguments(self):
+        with patch("python.services.github_service.GithubService.assign_support_issues_to_self") as mock:
+            mock.return_value = []
+            assign_support_tickets.main()
+
+    @patch("sys.argv", ["", "--oauth-token"])
+    def test_call_main_without_arguments(self):
+        with self.assertRaises(SystemExit) as cm:
+            assign_support_tickets.main()
+
+        self.assertEqual(cm.exception.code, 2)
+
+    @patch("sys.argv", ["", "--oauth-token", ""])
+    def test_add_default_arguments(self):
+        parser = assign_support_tickets.add_arguments()
+        self.assertEqual(parser.org, "ministryofjustice")
+        self.assertEqual(parser.repo, "operations-engineering")
+        self.assertEqual(parser.tag, "Support")
+        

--- a/python/test/test_assign_support_tickets.py
+++ b/python/test/test_assign_support_tickets.py
@@ -34,4 +34,3 @@ class TestAssignSupportTicket(unittest.TestCase):
         self.assertEqual(parser.org, "ministryofjustice")
         self.assertEqual(parser.repo, "operations-engineering")
         self.assertEqual(parser.tag, "Support")
-        

--- a/python/test/test_github_service.py
+++ b/python/test/test_github_service.py
@@ -577,7 +577,8 @@ class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
 
     def test_call_with_nothing_to_assign(self):
         github_service = GithubService("", ORGANISATION_NAME)
-        issues = github_service.assign_support_issues_to_self("test_repository_name", "test_org", "test_support_label")
+        issues = github_service.assign_support_issues_to_self(
+            "test_repository_name", "test_org", "test_support_label")
 
         self.assertEqual(issues, [])
 
@@ -588,26 +589,31 @@ class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
 
         github_service = GithubService("", ORGANISATION_NAME)
 
-        self.assertRaises(ValueError, github_service.assign_support_issues_to_self, "test_repository_name", "test_org", mock.name)
+        self.assertRaises(ValueError, github_service.assign_support_issues_to_self,
+                          "test_repository_name", "test_org", mock.name)
 
     @patch("python.services.github_service.GithubService.get_support_issues")
     def test_with_correct_issue(self, open_issues_mock):
-        mock_issue = MockGithubIssue(123, 456, "test complete", [], ["test_support_label"])
+        mock_issue = MockGithubIssue(
+            123, 456, "test complete", [], ["test_support_label"])
         open_issues_mock.return_value = [mock_issue]
 
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.assign_support_issues_to_self("test_repository_name", "test_org", "test_support_label")
+        issues = github_service.assign_support_issues_to_self(
+            "test_repository_name", "test_org", "test_support_label")
 
         self.assertEqual(issues, [mock_issue])
 
     @patch("python.services.github_service.GithubService.get_open_issues_from_repo")
     def test_get_support_issues(self, mock_get_open_issues_from_repo):
-        mock_issue = MockGithubIssue(123, 456, "test getting issue", [], ["test_support_label"])
+        mock_issue = MockGithubIssue(
+            123, 456, "test getting issue", [], ["test_support_label"])
         mock_get_open_issues_from_repo.return_value = [mock_issue]
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.get_support_issues("test_org/get_support", mock_issue.labels[0].name)
+        issues = github_service.get_support_issues(
+            "test_org/get_support", mock_issue.labels[0].name)
 
         self.assertEqual(issues, [mock_issue])
 
@@ -616,22 +622,26 @@ class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
         mock_get_open_issues_from_repo.return_value = []
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.get_support_issues("test_org/test_with_no_issues", "test_support_label")
+        issues = github_service.get_support_issues(
+            "test_org/test_with_no_issues", "test_support_label")
 
         self.assertEqual(issues, [])
 
     def test_assign_issues_to_self(self):
-        mock_issue = MockGithubIssue(123, 456, "testing assign", [], ["test_support_label"])
+        mock_issue = MockGithubIssue(
+            123, 456, "testing assign", [], ["test_support_label"])
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.assign_issues_to_self([mock_issue], "test_org/test_assign")
+        issues = github_service.assign_issues_to_self(
+            [mock_issue], "test_org/test_assign")
 
         self.assertEqual(issues, [mock_issue])
 
     def test_assign_issues_to_self_with_no_issues(self):
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.assign_issues_to_self([], "test_org/test_repository_name")
+        issues = github_service.assign_issues_to_self(
+            [], "test_org/test_repository_name")
 
         self.assertEqual(issues, [])
 

--- a/python/test/test_github_service.py
+++ b/python/test/test_github_service.py
@@ -592,7 +592,7 @@ class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
 
     @patch("python.services.github_service.GithubService.get_support_issues")
     def test_with_correct_issue(self, open_issues_mock):
-        mock_issue = MockGithubIssue(123, 456, "test title", [], ["test_support_label"])
+        mock_issue = MockGithubIssue(123, 456, "test complete", [], ["test_support_label"])
         open_issues_mock.return_value = [mock_issue]
 
         github_service = GithubService("", ORGANISATION_NAME)
@@ -603,11 +603,11 @@ class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
 
     @patch("python.services.github_service.GithubService.get_open_issues_from_repo")
     def test_get_support_issues(self, mock_get_open_issues_from_repo):
-        mock_issue = MockGithubIssue(123, 456, "test title", [], ["test_support_label"])
+        mock_issue = MockGithubIssue(123, 456, "test getting issue", [], ["test_support_label"])
         mock_get_open_issues_from_repo.return_value = [mock_issue]
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.get_support_issues("test_org/test_repository_name", mock_issue.labels[0].name)
+        issues = github_service.get_support_issues("test_org/get_support", mock_issue.labels[0].name)
 
         self.assertEqual(issues, [mock_issue])
 
@@ -616,15 +616,15 @@ class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
         mock_get_open_issues_from_repo.return_value = []
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.get_support_issues("test_org/test_repository_name", "test_support_label")
+        issues = github_service.get_support_issues("test_org/test_with_no_issues", "test_support_label")
 
         self.assertEqual(issues, [])
 
     def test_assign_issues_to_self(self):
-        mock_issue = MockGithubIssue(123, 456, "test title", [], ["test_support_label"])
+        mock_issue = MockGithubIssue(123, 456, "testing assign", [], ["test_support_label"])
         github_service = GithubService("", ORGANISATION_NAME)
 
-        issues = github_service.assign_issues_to_self([mock_issue], "test_org/test_repository_name")
+        issues = github_service.assign_issues_to_self([mock_issue], "test_org/test_assign")
 
         self.assertEqual(issues, [mock_issue])
 

--- a/python/test/test_github_service.py
+++ b/python/test/test_github_service.py
@@ -570,5 +570,86 @@ class TestGithubServiceGetPaginatedListOfUserNames(unittest.TestCase):
             101)
 
 
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
+@patch("github.Github.__new__", new=MagicMock)
+class TestGithubServiceAssignSupportToSelf(unittest.TestCase):
+
+    def test_call_with_nothing_to_assign(self):
+        github_service = GithubService("", ORGANISATION_NAME)
+        issues = github_service.assign_support_issues_to_self("test_repository_name", "test_org", "test_support_label")
+
+        self.assertEqual(issues, [])
+
+    @patch("python.services.github_service.GithubService.get_support_issues")
+    def test_with_correct_issue_but_fail(self, open_issues_mock):
+        mock = MagicMock()
+        open_issues_mock.return_value = [MagicMock()]
+
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        self.assertRaises(ValueError, github_service.assign_support_issues_to_self, "test_repository_name", "test_org", mock.name)
+
+    @patch("python.services.github_service.GithubService.get_support_issues")
+    def test_with_correct_issue(self, open_issues_mock):
+        mock_issue = MockGithubIssue(123, 456, "test title", [], ["test_support_label"])
+        open_issues_mock.return_value = [mock_issue]
+
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        issues = github_service.assign_support_issues_to_self("test_repository_name", "test_org", "test_support_label")
+
+        self.assertEqual(issues, [mock_issue])
+
+    @patch("python.services.github_service.GithubService.get_open_issues_from_repo")
+    def test_get_support_issues(self, mock_get_open_issues_from_repo):
+        mock_issue = MockGithubIssue(123, 456, "test title", [], ["test_support_label"])
+        mock_get_open_issues_from_repo.return_value = [mock_issue]
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        issues = github_service.get_support_issues("test_org/test_repository_name", mock_issue.labels[0].name)
+
+        self.assertEqual(issues, [mock_issue])
+
+    @patch("python.services.github_service.GithubService.get_open_issues_from_repo")
+    def test_get_support_issues_with_no_issues(self, mock_get_open_issues_from_repo):
+        mock_get_open_issues_from_repo.return_value = []
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        issues = github_service.get_support_issues("test_org/test_repository_name", "test_support_label")
+
+        self.assertEqual(issues, [])
+
+    def test_assign_issues_to_self(self):
+        mock_issue = MockGithubIssue(123, 456, "test title", [], ["test_support_label"])
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        issues = github_service.assign_issues_to_self([mock_issue], "test_org/test_repository_name")
+
+        self.assertEqual(issues, [mock_issue])
+
+    def test_assign_issues_to_self_with_no_issues(self):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        issues = github_service.assign_issues_to_self([], "test_org/test_repository_name")
+
+        self.assertEqual(issues, [])
+
+
+class MockGithubIssue(MagicMock):
+    def __init__(self, id, number, title, assignees, label):
+        mock_label = MagicMock(name="test_support_label")
+        super().__init__()
+        self.id = id
+        self.number = number
+        self.title = title
+        self.assignees = assignees
+        self.labels = [mock_label]
+        self.user = MagicMock()
+
+    def edit(self, assignees):
+        self.assignees = assignees
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Overview
---

This PR refactors the auto-assignment script and adds almost full test coverage. It leverages the new GitHub service layer and creates additional business logic to:

- grab all open issues in the repository passed to it.
- identify the issues labelled with the tag passed to it.
- assign the issue to the user who raised the issue.

There is no additional functionality here, only the ability to change the script and supporting service layer.