### PR TITLE
Update ADR

### DIFF
--- a/source/documentation/adrs/adr-004.html.md.erb
+++ b/source/documentation/adrs/adr-004.html.md.erb
@@ -1,11 +1,11 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: ADR-004 Docker SSO
-last_reviewed_on: 2022-12-15
+last_reviewed_on: 2022-04-05
 review_in: 6 months
 ---
 
-# ADR-004 DNS Failover
+# ADR-004 Docker SSO
 
 ## Status
 
@@ -15,7 +15,7 @@ review_in: 6 months
 
 Operations Engineering manages the Docker organisation for the MoJ. Docker have now introduced Single Sign-On (SSO) as an option for people to authenticate. We have set this up with Auth0.
 
-We use Github as our identity provider. This means that when someone joins or leaves the MoJ Github organisation, this will be reflected in the Docker organisation.
+We use Github as our identity provider.
 
 ## Decision
 


### PR DESCRIPTION
Updates page title and removes statement that user access is syncs with changes to the GitHub Org which is not correct. New users most opt into Docker org. Removal of leavers is a manual process.