### PR TITLE
refactor(dependabot): change schedule to run at 0915

### DIFF
--- a/.github/workflows/move-dependabot-issues.yml
+++ b/.github/workflows/move-dependabot-issues.yml
@@ -2,7 +2,7 @@ name: Move all dependabot issues to "Refined and Ready"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "* */12 * * 1-5" # Every 12 hours, Monday through Friday
+    - cron: "15 9 * * mon-fri" # weekdays at 0915. Dependabot runs at 0900.
 
 jobs:
   run-script:


### PR DESCRIPTION
This commit changes when the dependabot issues lookup occurs. All dependabot checks for operations-engineering repositories should complete by 0915, which means this action only needs to run once per day at 0915.