### PR TITLE
Change link check time to 0205

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "5 4 * * 0-5"
+    - cron: "5 2 * * 0-5"
 
 jobs:
   linkChecker:


### PR DESCRIPTION
At 0400 we clash with the github standards report work, which coincidently fails this check.