### PR TITLE
Don't always publish the ops eng documentation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "docs/**"
+    paths:
+      - "source/**"
 
 # GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
I've noticed this pipeline always triggers every commit to this repo. It's a waste of compute in most cases and should only trigger when the documentation changes.