### PR TITLE
And runbook to address shortcut conflicts

### DIFF
--- a/source/documentation/runbooks.html.md.erb
+++ b/source/documentation/runbooks.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Runbooks
-last_reviewed_on: 2023-05-04
+last_reviewed_on: 2023-05-18
 review_in: 3 months
 ---
 
@@ -51,6 +51,7 @@ Documentation supporting day to day processes in the Operations Engineering team
 * [1Password User Account Recovery](runbooks/services/1password-recovery.html)
 * [Groups and Vaults](runbooks/services/1password-vaults-and-groups.html)
 * [Issue - Users unable to import via the 1Password App](runbooks/services/1password-import-issue.html)
+* [Issue - Google Docs keyboard shortcut also used to open the 1Password browser extension](runbooks/services/1password-chrome-extension-conflict.html)
 
 ### Github
 

--- a/source/documentation/runbooks/services/1password-chrome-extension-conflict.html.md.erb
+++ b/source/documentation/runbooks/services/1password-chrome-extension-conflict.html.md.erb
@@ -9,7 +9,7 @@ review_in: 3 months
 
 This is an FAQ.
 
-You can open the 1Password Browser Extenion useing the Keyboard shortcut `⌘ + Shift + X`. However, this is the same keyboard shortcur for `strikethrough` in Google Docs. Users have reported trying to format a document using the shortcut only to have the 1Password extension continuosly popping up. 
+You can open the 1Password Browser Extenion useing the Keyboard shortcut `⌘ + Shift + X`. However, this is the same keyboard shortcur for `strikethrough` in Google Docs. Users have reported trying to format a document using the shortcut only to have the 1Password extension continuosly popping up.
 
 ## Fix
 

--- a/source/documentation/runbooks/services/1password-chrome-extension-conflict.html.md.erb
+++ b/source/documentation/runbooks/services/1password-chrome-extension-conflict.html.md.erb
@@ -9,7 +9,7 @@ review_in: 3 months
 
 This is an FAQ.
 
-You can open the 1Password Browser Extenion useing the Keyboard shortcut `⌘ + Shift + X`. However, this is the same keyboard shortcur for `strikethrough` in Google Docs. Users have reported trying to format a document using the shortcut only to have the 1Password extension continuosly popping up.
+You can open the 1Password Browser Extension using the Keyboard shortcut `⌘ + Shift + X`. However, this is the same keyboard shortcut for `strikethrough` in Google Docs. Users have reported trying to format a document using the shortcut only to have the 1Password extension continuously popping up.
 
 ## Fix
 

--- a/source/documentation/runbooks/services/1password-chrome-extension-conflict.html.md.erb
+++ b/source/documentation/runbooks/services/1password-chrome-extension-conflict.html.md.erb
@@ -1,0 +1,16 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Issue - Google Docs keyboard shortcut also used to open the 1Password browser extension
+last_reviewed_on: 2023-05-18
+review_in: 3 months
+---
+
+# Issue - Google Docs keyboard shortcut also used to open the 1Password browser extension
+
+This is an FAQ.
+
+You can open the 1Password Browser Extenion useing the Keyboard shortcut `⌘ + Shift + X`. However, this is the same keyboard shortcur for `strikethrough` in Google Docs. Users have reported trying to format a document using the shortcut only to have the 1Password extension continuosly popping up. 
+
+## Fix
+
+Advise the user to change the keyboard shortcut for 1Password via the [Google Chrome Extension Shortcut settings](chrome://extensions/shortcuts).


### PR DESCRIPTION
1Password Chrome Extension and Google Docs use the same keyboard shortcut for different things which stops the user editing a document. This is a runbook to help the user fix this issue.