### PR TITLE
Change title and review date

### DIFF
--- a/source/documentation/runbooks/dns/check-domain-activity.html.md.erb
+++ b/source/documentation/runbooks/dns/check-domain-activity.html.md.erb
@@ -1,11 +1,11 @@
 ---
 owner_slack: "#operations-engineering-alerts"
-title: Checking Domain Activity
-last_reviewed_on: 2023-02-20
+title: How to check for domain activity before decommissioning
+last_reviewed_on: 2023-05-22
 review_in: 3 months
 ---
 
-# Checking Domain Activity
+# How to check for domain activity before decommissioning
 
 ## Overview
 


### PR DESCRIPTION
The title of this document requires the user to have some context of what they are reading. This isn't always the case. Changing it to "How to check for domain activity before decommissioning" describes the action, followed by instructions.