### PR TITLE
Add a document review checker

### DIFF
--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -51,9 +51,19 @@ def __needs_review(document: str) -> bool:
 
     return False
 
-def __fix_document(document: str) -> None:
-    print(f"Fixing document {document}")
-    pass
+def fix_date(file_name: str) -> None:
+    today = datetime.now().strftime('%Y-%m-%d')
+    date_pattern = r'\b\d{4}-\d{2}-\d{2}\b'
+
+    with open(file_name, 'r') as file:
+        content = file.read()
+
+    updated_content = re.sub(date_pattern, today, content)
+
+    with open(file_name, 'w') as file:
+        file.write(updated_content)
+
+    return None
 
 def main():
     parser = argparse.ArgumentParser(description="Document review checker")
@@ -64,16 +74,13 @@ def main():
     args = parser.parse_args()
 
 
-    documents = get_documents_due_for_review()
-    # TODO: Output list of documents to stdout
-    for document in documents:
+    docs_to_review = get_documents_due_for_review(args.file_path)
+    for document in docs_to_review:
         print(document)
-    # TODO: If fix argument is passed, update the document with the current date
     if args.fix:
         print("Fixing documents")
-        for document in documents:
-            __fix_document(document)
-        # TODO: Update the document with the current date
+        for document in docs_to_review:
+            fix_date(document)
 
 if __name__ == "__name__":
     main()

--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -10,8 +10,8 @@ that are due for review based on the current date, pass them
 to their editor of choice, and then update the document the date
 as they see fit.
 
-Stript execution:
-python python/scripts/document_review_checker.py --help
+Execution:
+python python.scripts.document_review_checker.py --help
 """
 import argparse
 import os
@@ -52,6 +52,7 @@ def __needs_review(document: str) -> bool:
     return False
 
 def fix_date(file_name: str) -> None:
+    """Update the date in the document to today's date"""
     today = datetime.now().strftime('%Y-%m-%d')
     date_pattern = r'\b\d{4}-\d{2}-\d{2}\b'
 

--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -17,6 +17,8 @@ import argparse
 import os
 import re
 from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
 
 def get_documents_due_for_review(file_path: str) -> list[str]:
     """Return a list of documents that are due for review"""
@@ -34,7 +36,6 @@ def get_documents_due_for_review(file_path: str) -> list[str]:
 def __needs_review(document: str) -> bool:
     today = datetime.today()
     date_pattern = r'\b\d{4}-\d{2}-\d{2}\b'
-    print("checking document", document)
 
 
     with open(document, 'r') as file:
@@ -45,7 +46,7 @@ def __needs_review(document: str) -> bool:
             date_format = "%Y-%m-%d"
 
             date_obj = datetime.strptime(date_str, date_format)
-            if date_obj < today:
+            if date_obj < today - relativedelta(months=3):
                 return True
 
     return False

--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -37,7 +37,6 @@ def __needs_review(document: str) -> bool:
     today = datetime.today()
     date_pattern = r'\b\d{4}-\d{2}-\d{2}\b'
 
-
     with open(document, 'r') as file:
         content = file.read()
         match = re.search(date_pattern, content)
@@ -50,6 +49,7 @@ def __needs_review(document: str) -> bool:
                 return True
 
     return False
+
 
 def fix_date(file_name: str) -> None:
     """Update the date in the document to today's date"""
@@ -66,13 +66,14 @@ def fix_date(file_name: str) -> None:
 
     return None
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--file-path",
         type=str,
         help="The path to the documentation directory",
-        default = os.path.join(os.getcwd(), "source", "documentation"),
+        default=os.path.join(os.getcwd(), "source", "documentation"),
     )
     parser.add_argument(
         "--fix",
@@ -82,7 +83,6 @@ def main():
     )
     args = parser.parse_args()
 
-
     docs_to_review = get_documents_due_for_review(args.file_path)
     for document in docs_to_review:
         print(document)
@@ -90,6 +90,7 @@ def main():
         print("Fixing documents")
         for document in docs_to_review:
             fix_date(document)
+
 
 if __name__ == "__main__":
     main()

--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -14,23 +14,47 @@ Stript execution:
 python python/scripts/document_review_checker.py --help
 """
 import argparse
+import os
+import re
+from datetime import datetime
 
-def get_documents_due_for_review() -> list[str]:
+def get_documents_due_for_review(file_path: str) -> list[str]:
     """Return a list of documents that are due for review"""
-    # TODO: Get the root of the repository
-    # TODO: Always look in the same place
-    # TODO: Iterate over the files in the directory
+    list_of_documents = []
+    for root, _, files in os.walk(file_path, topdown=True):
+        # if the file is a markdown file
+        for file in files:
+            file_path = os.path.join(root, file)
+            if file.endswith(".md.erb") and __needs_review(file_path):
+                list_of_documents.append(file_path)
 
-    return ["document1", "document2"]
+    return list_of_documents
 
+
+def __needs_review(document: str) -> bool:
+    today = datetime.today()
+    date_pattern = r'\b\d{4}-\d{2}-\d{2}\b'
+    print("checking document", document)
+
+
+    with open(document, 'r') as file:
+        content = file.read()
+        match = re.search(date_pattern, content)
+        if match:
+            date_str = match.group()
+            date_format = "%Y-%m-%d"
+
+            date_obj = datetime.strptime(date_str, date_format)
+            if date_obj < today:
+                return True
+
+    return False
 
 def __fix_document(document: str) -> None:
-    # TODO: Update the document with the current date
     print(f"Fixing document {document}")
     pass
 
 def main():
-    # TODO: Check arguments
     parser = argparse.ArgumentParser(description="Document review checker")
     parser.add_argument("--fix", action="store_true",
                         help="Update the document with the current date")
@@ -39,7 +63,6 @@ def main():
     args = parser.parse_args()
 
 
-    # TODO: Generate list of documents that are due for review
     documents = get_documents_due_for_review()
     # TODO: Output list of documents to stdout
     for document in documents:

--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -66,11 +66,19 @@ def fix_date(file_name: str) -> None:
     return None
 
 def main():
-    parser = argparse.ArgumentParser(description="Document review checker")
-    parser.add_argument("--fix", action="store_true",
-                        help="Update the document with the current date")
-    parser.add_argument("--file-path", type=str, default=".",
-                        help="Path to the directory containing the documents")
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--file-path",
+        type=str,
+        help="The path to the documentation directory",
+        default = os.path.join(os.getcwd(), "source", "documentation"),
+    )
+    parser.add_argument(
+        "--fix",
+        type=bool,
+        help="Update the document with the current date",
+        default=False,
+    )
     args = parser.parse_args()
 
 
@@ -82,5 +90,5 @@ def main():
         for document in docs_to_review:
             fix_date(document)
 
-if __name__ == "__name__":
+if __name__ == "__main__":
     main()

--- a/python/scripts/document_review_checker.py
+++ b/python/scripts/document_review_checker.py
@@ -1,0 +1,55 @@
+"""The document review checker module allows the caller
+to generate a list of documents that are due for review.
+
+As part of the support process in Operations Engineering,
+we have a number of documents that need to be reviewed
+on a three month cycle.
+
+The caller of this script can generate a list of documents
+that are due for review based on the current date, pass them
+to their editor of choice, and then update the document the date
+as they see fit.
+
+Stript execution:
+python python/scripts/document_review_checker.py --help
+"""
+import argparse
+
+def get_documents_due_for_review() -> list[str]:
+    """Return a list of documents that are due for review"""
+    # TODO: Get the root of the repository
+    # TODO: Always look in the same place
+    # TODO: Iterate over the files in the directory
+
+    return ["document1", "document2"]
+
+
+def __fix_document(document: str) -> None:
+    # TODO: Update the document with the current date
+    print(f"Fixing document {document}")
+    pass
+
+def main():
+    # TODO: Check arguments
+    parser = argparse.ArgumentParser(description="Document review checker")
+    parser.add_argument("--fix", action="store_true",
+                        help="Update the document with the current date")
+    parser.add_argument("--file-path", type=str, default=".",
+                        help="Path to the directory containing the documents")
+    args = parser.parse_args()
+
+
+    # TODO: Generate list of documents that are due for review
+    documents = get_documents_due_for_review()
+    # TODO: Output list of documents to stdout
+    for document in documents:
+        print(document)
+    # TODO: If fix argument is passed, update the document with the current date
+    if args.fix:
+        print("Fixing documents")
+        for document in documents:
+            __fix_document(document)
+        # TODO: Update the document with the current date
+
+if __name__ == "__name__":
+    main()

--- a/python/test/test_document_review_checker.py
+++ b/python/test/test_document_review_checker.py
@@ -1,0 +1,27 @@
+import unittest
+import tempfile
+
+import python.scripts.document_review_checker as document_review_checker
+
+class TestDocumentReviewChecker(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fix = True
+        self.file_path = "."
+
+
+    def test_get_documents_due_for_review(self):
+        # create a test file in the current directory
+        # call the function
+        # assert that the file is in the list
+        # TODO: Make sure you defer the file deletion until after the test
+        file = tempfile.NamedTemporaryFile(dir=self.file_path, delete=False)
+        file.write(b"last_reviewed_on: 2022-03-14")
+        file.close()
+
+        documents = document_review_checker.get_documents_due_for_review()
+        print(documents)
+        self.assertIn(file.name, documents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test/test_document_review_checker.py
+++ b/python/test/test_document_review_checker.py
@@ -5,14 +5,14 @@ from datetime import datetime
 
 from python.scripts import document_review_checker as check
 
+
 class TestDocumentReviewChecker(unittest.TestCase):
     def setUp(self) -> None:
         self.file_path = tempfile.mkdtemp()
 
-
     def test_documents_due_for_review(self):
         with tempfile.NamedTemporaryFile(
-            dir=self.file_path, delete=False, suffix=".md.erb") as file:
+                dir=self.file_path, delete=False, suffix=".md.erb") as file:
             file.write(b"last_reviewed_on: 2020-03-14")
             file.close()
 
@@ -24,8 +24,9 @@ class TestDocumentReviewChecker(unittest.TestCase):
     def test_no_documents_to_review(self):
         today = datetime.today()
         with tempfile.NamedTemporaryFile(
-            dir=self.file_path, delete=False, suffix=".md.erb") as file:
-            file.write(b"last_reviewed_on: %s" % today.strftime("%Y-%m-%d").encode())
+                dir=self.file_path, delete=False, suffix=".md.erb") as file:
+            file.write(b"last_reviewed_on: %s" %
+                       today.strftime("%Y-%m-%d").encode())
             file.close()
 
         self.addCleanup(os.remove, file.name)
@@ -39,10 +40,9 @@ class TestFixingDocumentDates(unittest.TestCase):
         self.fix = True
         self.file_path = tempfile.mkdtemp()
 
-
     def test_with_file_to_fix(self):
         with tempfile.NamedTemporaryFile(
-            dir=self.file_path, delete=False, suffix=".md.erb") as file:
+                dir=self.file_path, delete=False, suffix=".md.erb") as file:
             file.write(b"last_reviewed_on: 2020-03-14")
             file.close()
 

--- a/python/test/test_document_review_checker.py
+++ b/python/test/test_document_review_checker.py
@@ -1,6 +1,7 @@
 import unittest
 import tempfile
 import os
+from datetime import datetime
 
 from python.scripts import document_review_checker as check
 
@@ -10,7 +11,7 @@ class TestDocumentReviewChecker(unittest.TestCase):
         self.file_path = tempfile.mkdtemp()
 
 
-    def test_get_documents_due_for_review(self):
+    def test_documents_due_for_review(self):
         with tempfile.NamedTemporaryFile(
             dir=self.file_path, delete=False, suffix=".md.erb") as file:
             file.write(b"last_reviewed_on: 2020-03-14")
@@ -21,6 +22,17 @@ class TestDocumentReviewChecker(unittest.TestCase):
         documents = check.get_documents_due_for_review(self.file_path)
         self.assertIn(file.name, documents)
 
+    def test_no_documents_to_review(self):
+        today = datetime.today()
+        with tempfile.NamedTemporaryFile(
+            dir=self.file_path, delete=False, suffix=".md.erb") as file:
+            file.write(b"last_reviewed_on: %s" % today.strftime("%Y-%m-%d").encode())
+            file.close()
+
+        self.addCleanup(os.remove, file.name)
+
+        documents = check.get_documents_due_for_review(self.file_path)
+        self.assertNotIn(file.name, documents)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/test/test_document_review_checker.py
+++ b/python/test/test_document_review_checker.py
@@ -1,25 +1,24 @@
 import unittest
 import tempfile
+import os
 
-import python.scripts.document_review_checker as document_review_checker
+from python.scripts import document_review_checker as check
 
 class TestDocumentReviewChecker(unittest.TestCase):
     def setUp(self) -> None:
         self.fix = True
-        self.file_path = "."
+        self.file_path = tempfile.mkdtemp()
 
 
     def test_get_documents_due_for_review(self):
-        # create a test file in the current directory
-        # call the function
-        # assert that the file is in the list
-        # TODO: Make sure you defer the file deletion until after the test
-        file = tempfile.NamedTemporaryFile(dir=self.file_path, delete=False)
-        file.write(b"last_reviewed_on: 2022-03-14")
-        file.close()
+        with tempfile.NamedTemporaryFile(
+            dir=self.file_path, delete=False, suffix=".md.erb") as file:
+            file.write(b"last_reviewed_on: 2020-03-14")
+            file.close()
 
-        documents = document_review_checker.get_documents_due_for_review()
-        print(documents)
+        self.addCleanup(os.remove, file.name)
+
+        documents = check.get_documents_due_for_review(self.file_path)
         self.assertIn(file.name, documents)
 
 

--- a/python/test/test_document_review_checker.py
+++ b/python/test/test_document_review_checker.py
@@ -7,7 +7,6 @@ from python.scripts import document_review_checker as check
 
 class TestDocumentReviewChecker(unittest.TestCase):
     def setUp(self) -> None:
-        self.fix = True
         self.file_path = tempfile.mkdtemp()
 
 
@@ -33,6 +32,30 @@ class TestDocumentReviewChecker(unittest.TestCase):
 
         documents = check.get_documents_due_for_review(self.file_path)
         self.assertNotIn(file.name, documents)
+
+
+class TestFixingDocumentDates(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fix = True
+        self.file_path = tempfile.mkdtemp()
+
+
+    def test_with_file_to_fix(self):
+        with tempfile.NamedTemporaryFile(
+            dir=self.file_path, delete=False, suffix=".md.erb") as file:
+            file.write(b"last_reviewed_on: 2020-03-14")
+            file.close()
+
+        self.addCleanup(os.remove, file.name)
+
+        documents = check.get_documents_due_for_review(self.file_path)
+        self.assertIn(file.name, documents)
+
+        check.fix_date(file.name)
+
+        documents = check.get_documents_due_for_review(self.file_path)
+        self.assertNotIn(file.name, documents)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Overview
---

While on support, I noticed I had to perform several document review checks. To make this easier, the below script will output the `.md.erb` files that are 3 months out of date.
Executing the following:

```bash
python -m python.scripts.document_review_checker
```

Returns all documentation that is considered out of date. If you have a decent editor, you can pass this as an argument to view all the documents simultaneously. For example:

```bash
vim -p `python -m python.scripts.document_review_checker`
```

If (and only if) you have reviewed the documentation and decide you want to update all the documentation review dates at the same time, you can pass the following flag:

```bash
python -m python.scripts.document_review_checker --fix=true
```

Which amends the last_reviewed date to today's date. You'll then need to commit and PR, etc.