### PR TITLE
Remove Encryption from GitHub Repository Reports

### DIFF
--- a/python/scripts/report_on_repository_standards.py
+++ b/python/scripts/report_on_repository_standards.py
@@ -6,7 +6,7 @@ from python.services.operations_engineering_reports import OperationsEngineering
 from python.services.standards_service import RepositoryReport
 
 
-def add_arguments():
+def __add_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--oauth-token",
@@ -43,32 +43,22 @@ def add_arguments():
         help="The API key to use for the operations-engineering-reports endpoint",
     )
 
-    parser.add_argument(
-        "--enc-key",
-        type=str,
-        required=True,
-        help="The encryption key to use for the operations-engineering-reports endpoint",
-    )
-
     return parser.parse_args()
 
 
-def parse_args(args):
+def __parse_args(args):
     if args.url[-1] == "/":
         args.url = args.url[:-1]
 
     if args.endpoint[0] == "/":
         args.endpoint = args.endpoint[1:]
 
-    if args.enc_key[:2] == "0x":
-        args.enc_key = args.enc_key[2:]
-
     return args
 
 
 def main():
     # Add arguments from the command line
-    args = parse_args(add_arguments())
+    args = __parse_args(__add_arguments())
 
     # Fetch all repositories in the org
     repos = GithubService(
@@ -79,7 +69,7 @@ def main():
 
     # Send the reports to the operations-engineering-reports API
     try:
-        OperationsEngineeringReportsService(args.url, args.endpoint, args.api_key, args.enc_key)\
+        OperationsEngineeringReportsService(args.url, args.endpoint, args.api_key)\
             .override_repository_standards_reports(repo_reports)
     except AssertionError as error:
         logging.error(

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -20,7 +20,7 @@ class OperationsEngineeringReportsService:
         self.__endpoint = endpoint
         self.__api_key = api_key
 
-    def override_repository_standards_reports(self, reports: list[str]) -> None:
+    def override_repository_standards_reports(self, reports: list[dict]) -> None:
         """Send a list of GitHubRepositoryStandardsReport objects represented as json objects
         to the operations-engineering-reports API endpoint. This will overwrite any existing
         reports for the given repositories.
@@ -38,7 +38,7 @@ class OperationsEngineeringReportsService:
             raise AssertionError(
                 f"Received status code {status} from {self.__reports_url}/{self.__endpoint}")
 
-    def __http_post(self, data: list[str]) -> int:
+    def __http_post(self, data: list[dict]) -> int:
         headers = {
             "Content-Type": "application/json",
             "X-API-KEY": self.__api_key,

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -1,7 +1,6 @@
 import json
 
 import requests
-from cryptography.fernet import Fernet
 
 
 class OperationsEngineeringReportsService:
@@ -16,11 +15,10 @@ class OperationsEngineeringReportsService:
 
     """
 
-    def __init__(self, url: str, endpoint: str, api_key: str, enc_key: hex) -> None:
+    def __init__(self, url: str, endpoint: str, api_key: str) -> None:
         self.__reports_url = url
         self.__endpoint = endpoint
         self.__api_key = api_key
-        self.__encryption_key = enc_key
 
     def override_repository_standards_reports(self, reports: list[str]) -> None:
         """Send a list of GitHubRepositoryStandardsReport objects represented as json objects
@@ -35,14 +33,12 @@ class OperationsEngineeringReportsService:
             Exception: If the status code of the POST request is not 200.
 
         """
-        data = self.__encrypt(reports)
-
-        status = self.__http_post(data)
+        status = self.__http_post(reports)
         if status != 200:
             raise AssertionError(
                 f"Received status code {status} from {self.__reports_url}/{self.__endpoint}")
 
-    def __http_post(self, data) -> int:
+    def __http_post(self, data: list[str]) -> int:
         headers = {
             "Content-Type": "application/json",
             "X-API-KEY": self.__api_key,
@@ -52,14 +48,3 @@ class OperationsEngineeringReportsService:
         url = f"{self.__reports_url}/{self.__endpoint}"
 
         return requests.post(url, headers=headers, json=data, timeout=3).status_code
-
-    def __encrypt(self, payload: any):
-        key = bytes.fromhex(self.__encryption_key)
-        fernet = Fernet(key)
-
-        # The payload must be able to be serialised to json
-        encrypted_data_as_bytes = fernet.encrypt(
-            json.dumps(payload).encode())
-        encrypted_data_bytes_as_string = encrypted_data_as_bytes.decode()
-
-        return encrypted_data_bytes_as_string

--- a/python/services/standards_service.py
+++ b/python/services/standards_service.py
@@ -55,7 +55,7 @@ class RepositoryReport:
         )
 
     @property
-    def output(self) -> str:
+    def output(self) -> GitHubRepositoryStandardsReport:
         """Return the report as a json object."""
         return self.__output.to_json()
 

--- a/python/test/test_operations_engineering_report.py
+++ b/python/test/test_operations_engineering_report.py
@@ -34,11 +34,9 @@ class TestOrganisationStandardsReport(unittest.TestCase):
         self.url = 'https://test.com'
         self.endpoint = 'test'
         self.api_key = 'secret'
-        # Fake test hex key
-        self.encryption_key = "5a5263317379674b64564a62516856656a504a6e4b386a4959544236626f44365631516531534a4c3165773d"
 
         self.report_service = OperationsEngineeringReportsService(
-            self.url, self.endpoint, self.api_key, self.encryption_key)
+            self.url, self.endpoint, self.api_key)
 
     def test_success_init(self):
         self.assertIsNotNone(self.report_service)
@@ -50,9 +48,9 @@ class TestOrganisationStandardsReport(unittest.TestCase):
             OperationsEngineeringReportsService(endpoint, api_key)
 
     @requests_mock.Mocker()
-    def test_success_override_repository_standards(self, m):
+    def test_success_override_repository_standards(self, mock):
         url = f"{self.url}/{self.endpoint}"
-        m.post(url, status_code=http.HTTPStatus.OK)
+        mock.post(url, status_code=http.HTTPStatus.OK)
         self.report_service.override_repository_standards_reports(
             self.mock_report)
 
@@ -76,15 +74,6 @@ class TestOrganisationStandardsReport(unittest.TestCase):
         m.post(url, status_code=http.HTTPStatus.OK)
         self.assertRaises(
             TypeError, self.report_service.override_repository_standards_reports('bad_payload'))
-
-    @requests_mock.Mocker()
-    def test_bad_encrypt_override_repository_standards(self, m):
-        url = f"{self.url}/{self.endpoint}"
-        m.post(url, status_code=http.HTTPStatus.OK)
-        bad_key = OperationsEngineeringReportsService(
-            self.url, self.endpoint, self.api_key, 1)
-        self.assertRaises(
-            TypeError, bad_key.override_repository_standards_reports, self.mock_report)
 
     @requests_mock.Mocker()
     def test_bad_report_override_repository_standards(self, m):


### PR DESCRIPTION
Overview
---

It was decided that we no longer require data encrypted before we send it to the Operations Engineering Reports API. This was previously a non-functional requirement that's no longer needed, so this PR removes the method and all calls made before POST'ing to the API. 

