### PR TITLE
Add the Notify service and unit tests

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,3 +10,4 @@ jwt
 cryptography
 coverage
 requests-mock
+notifications-python-client

--- a/python/services/notify_service.py
+++ b/python/services/notify_service.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+import requests
+from notifications_python_client.notifications import NotificationsAPIClient
+from python.config.logging_config import logging
+
+
+class NotifyService:
+    def __init__(self, config, api_key):
+        self.config = config
+        self.api_key = api_key
+        self.operations_engineering_email_id = "6767e190-996f-462c-b7f8-9bafe7b96a01"
+
+    def _get_notifications_by_type_and_status(self, template_type, status):
+        return NotificationsAPIClient(self.api_key).get_all_notifications(status=status, template_type=template_type)
+
+    def check_for_undelivered_emails_for_template(self, template_id):
+        logging.debug("check_for_undelivered_emails_for_template")
+        notifications = self._get_notifications_by_type_and_status('email', 'failed')[
+            'notifications']
+        today = datetime.now(timezone.utc).date()
+
+        undelivered_emails = []
+
+        for notification in notifications:
+            created_at = datetime.fromisoformat(
+                notification['created_at']).date()
+
+            if notification['template']['id'] == template_id and created_at == today:
+                undelivered_email = {
+                    "email_address": notification['email_address'],
+                    "created_at": created_at,
+                    "status": notification['status']
+                }
+                undelivered_emails.append(undelivered_email)
+        return undelivered_emails
+
+    def send_email_reply_to_ops_eng(self, template_id: str, email: str, personalisation: dict):
+        logging.debug("send_email_reply_to_ops_eng")
+        try:
+            NotificationsAPIClient(self.api_key).send_email_notification(
+                email_address=email,
+                template_id=template_id,
+                personalisation=personalisation,
+                email_reply_to_id=self.operations_engineering_email_id
+            )
+        except requests.exceptions.HTTPError as api_key_error:
+            raise requests.exceptions.HTTPError(
+                f"You may need to export your Notify API Key:\n {api_key_error}"
+            ) from api_key_error

--- a/python/test/test_config.py
+++ b/python/test/test_config.py
@@ -1,0 +1,18 @@
+test_config = {
+    "keys": {
+        "gandi_api_key": "test_key",
+        "notify_api_key": "test_key",
+    },
+    "template_ids": {
+        "cert_expiry": "test_template_id"
+    },
+    "urls": {
+        "gandi_base_url": "test_base_url",
+        "gandi_cert_url_extension": "test_cert_url_extension",
+    },
+    "cert_expiry_thresholds": [30, 15, 1],
+    "reply_email": "test_reply_email",
+    "gandi": {
+        "topup_amount": "test_amount"
+    }
+}

--- a/python/test/test_notify_service.py
+++ b/python/test/test_notify_service.py
@@ -77,6 +77,8 @@ class TestSendEmailReplyToOpsEng(unittest.TestCase):
                 self.template_id, self.ops_email, self.data_to_send)
 
 # pylint: disable=W0212
+
+
 @patch("python.services.notify_service.NotificationsAPIClient")
 class TestGetNotificationsByTypeAndStatus(unittest.TestCase):
 

--- a/python/test/test_notify_service.py
+++ b/python/test/test_notify_service.py
@@ -1,0 +1,97 @@
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+import requests
+from python.services.notify_service import NotifyService
+from python.tests.test_config import test_config
+
+
+class TestCheckForUndeliveredEmailsFromNotify(unittest.TestCase):
+
+    def setUp(self):
+        self.config = test_config
+        self.api_key = "test_api_key"
+        self.notify_service = NotifyService(self.config, self.api_key)
+        self.template_id = "test_template_id"
+
+    @patch.object(NotifyService, "_get_notifications_by_type_and_status")
+    def test_undelivered_emails_not_found_returns_none(self, mock_get_notifications_by_type_and_status):
+        mock_get_notifications_by_type_and_status.return_value = {
+            "notifications": []
+        }
+
+        result = self.notify_service.check_for_undelivered_emails_for_template(
+            self.template_id)
+        self.assertEqual(len(result), 0)
+
+    @patch.object(NotifyService, "_get_notifications_by_type_and_status")
+    def test_undelivered_emails_found_returns_expected_data(self, mock_get_notifications_by_type_and_status):
+        today = datetime.now(timezone.utc).date()
+        mock_get_notifications_by_type_and_status.return_value = {
+            "notifications": [
+                {
+                    "template": {"id": self.template_id},
+                    "email_address": "test@example.com",
+                    "created_at": today.isoformat(),
+                    "status": "failed"
+                }
+            ]
+        }
+
+        result = self.notify_service.check_for_undelivered_emails_for_template(
+            self.template_id)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["email_address"], "test@example.com")
+        self.assertEqual(result[0]["created_at"], today)
+        self.assertEqual(result[0]["status"], "failed")
+
+
+@patch("python.services.notify_service.NotificationsAPIClient")
+class TestSendEmailReplyToOpsEng(unittest.TestCase):
+
+    def setUp(self):
+        self.config = test_config
+        self.api_key = "test_api_key"
+        self.template_id = "test_template_id"
+        self.ops_email = "test_ops_email"
+        self.data_to_send = {"some-data": "the_data"}
+        self.email_reply_to_id = '6767e190-996f-462c-b7f8-9bafe7b96a01'
+        self.notify_service = NotifyService(self.config, self.api_key)
+
+    def test_send_email_reply_to_ops_eng(self, mock_notifications_api_client):
+        mock_notifications_api_client.return_value.send_email_notification.return_value = None
+        self.notify_service.send_email_reply_to_ops_eng(
+            self.template_id, self.ops_email, self.data_to_send)
+        mock_notifications_api_client.return_value.send_email_notification.assert_called_once_with(
+            email_address=self.ops_email,
+            template_id=self.template_id,
+            personalisation=self.data_to_send,
+            email_reply_to_id=self.email_reply_to_id
+        )
+
+    def test_send_email_reply_to_ops_eng_raises_exception(self, mock_notifications_api_client):
+        mock_notifications_api_client.return_value.send_email_notification.side_effect = requests.exceptions.HTTPError
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.notify_service.send_email_reply_to_ops_eng(
+                self.template_id, self.ops_email, self.data_to_send)
+
+# pylint: disable=W0212
+@patch("python.services.notify_service.NotificationsAPIClient")
+class TestGetNotificationsByTypeAndStatus(unittest.TestCase):
+
+    def setUp(self):
+        self.config = test_config
+        self.api_key = "test_api_key"
+        self.notify_service = NotifyService(self.config, self.api_key)
+
+    def test_get_notifications_by_type_and_status(self, mock_notifications_api_client):
+        mock_notifications_api_client.return_value.get_all_notifications.return_value = [
+            "notification1", "notification2"]
+        result = self.notify_service._get_notifications_by_type_and_status(
+            'email', 'failed')
+        self.assertEqual(result, ["notification1", "notification2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test/test_notify_service.py
+++ b/python/test/test_notify_service.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 import requests
 from python.services.notify_service import NotifyService
-from python.tests.test_config import test_config
+from python.test.test_config import test_config
 
 
 class TestCheckForUndeliveredEmailsFromNotify(unittest.TestCase):


### PR DESCRIPTION
This is the Notify service taken from the [operations-engineering-certificate-renewal](https://github.com/ministryofjustice/operations-engineering-certificate-renewal) repo. 

The code for review are the additional functions and classes added to the files:
send_email_reply_to_ops_eng()
class TestSendEmailReplyToOpsEng
class TestGetNotificationsByTypeAndStatus