### PR TITLE
🐛 Fix timeouts and branch failures on reports 

### DIFF
--- a/python/scripts/report_on_repository_standards.py
+++ b/python/scripts/report_on_repository_standards.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 
 from python.services.github_service import GithubService
-from python.services.operations_engineering_reports import OperationsEngineeringReportsService
+from python.services.operations_engineering_reports import OperationsEngineeringReportsService as reports_service
 from python.services.standards_service import RepositoryReport
 
 
@@ -68,12 +68,8 @@ def main():
     repo_reports = [RepositoryReport(repo).output for repo in repos]
 
     # Send the reports to the operations-engineering-reports API
-    try:
-        OperationsEngineeringReportsService(args.url, args.endpoint, args.api_key)\
-            .override_repository_standards_reports(repo_reports)
-    except AssertionError as error:
-        logging.error(
-            f" A failure occurred communicating with {args.url}/{args.endpoint}: {error}")
+    reports_service(args.url, args.endpoint, args.api_key)\
+        .override_repository_standards_reports(repo_reports)
 
 
 if __name__ == "__main__":

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -45,4 +45,4 @@ class OperationsEngineeringReportsService:
 
         url = f"{self.__reports_url}/{self.__endpoint}"
 
-        return requests.post(url, headers=headers, json=data, timeout=3).status_code
+        return requests.post(url, headers=headers, json=data, timeout=30).status_code

--- a/python/services/standards_service.py
+++ b/python/services/standards_service.py
@@ -55,7 +55,7 @@ class RepositoryReport:
         )
 
     @property
-    def output(self) -> GitHubRepositoryStandardsReport:
+    def output(self) -> str:
         """Return the report as a json object."""
         return self.__output.to_json()
 
@@ -63,6 +63,8 @@ class RepositoryReport:
         return self.__github_data["node"]["name"]
 
     def __default_branch(self) -> str:
+        if self.__github_data["node"]["defaultBranchRef"] is None:
+            return "unknown"
         return self.__github_data["node"]["defaultBranchRef"]["name"]
 
     def __url(self) -> str:
@@ -96,9 +98,14 @@ class RepositoryReport:
         }
 
     def __default_branch_main(self) -> bool:
+        if self.__github_data["node"]["defaultBranchRef"] is None:
+            return False
         return self.__github_data["node"]["defaultBranchRef"]["name"] == "main"
 
     def __has_default_branch_protection_enabled(self) -> bool:
+        if self.__github_data["node"]["defaultBranchRef"] is None:
+            return False
+
         default_branch = self.__github_data["node"]["defaultBranchRef"]["name"]
         branch_protection_rules = self.__github_data["node"]["branchProtectionRules"]["edges"]
         for branch_protection_rule in branch_protection_rules:

--- a/python/test/test_standards_service.py
+++ b/python/test/test_standards_service.py
@@ -136,6 +136,38 @@ class TestNonCompliantRepositoryReport(unittest.TestCase):
         self.assertEqual(self.to_json['report']
                          ['has_require_approvals_enabled'], False)
 
+    def test_empty_branch_condition(self):
+        empty_data_set = {
+            "node": {
+                "branchProtectionRules": {
+                    "edges": [
+                        {
+                            "node": {
+                                "pattern": "not_main",
+                                "requiresApprovingReviews": False,
+                                "isAdminEnforced": False,
+                                "requiresCodeOwnerReviews": True,
+                                "requiredApprovingReviewCount": 0,
+                            }
+                        }
+                    ]
+                },
+                "defaultBranchRef": None,
+                "description": "repo_description",
+                "hasIssuesEnabled": False,
+                "isArchived": False,
+                "isDisabled": False,
+                "isLocked": False,
+                "isPrivate": True,
+                "licenseInfo": None,
+                "name": "repo_name",
+                "pushedAt": "2022-01-01",
+                "url": "https://github.com"
+            }
+        }
+        repository_report = RepositoryReport(empty_data_set)
+        to_json = json.loads(repository_report.output)
+        self.assertEqual(to_json['report']['default_branch_main'], False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_standards_service.py
+++ b/python/test/test_standards_service.py
@@ -169,5 +169,6 @@ class TestNonCompliantRepositoryReport(unittest.TestCase):
         to_json = json.loads(repository_report.output)
         self.assertEqual(to_json['report']['default_branch_main'], False)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes two issues with the operations-engineering github standards reports.
1. It increases the timeout when sending reports to the API.
2. It fixes a condition where a default branch name doesn't exist.