### PR TITLE
Use PyJWT over jwt in requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ aiohttp
 slack_sdk == 3.20.2
 freezegun==1.2.2
 pyaml-env
-jwt
+PyJWT
 cryptography
 coverage
 requests-mock


### PR DESCRIPTION
PyJWT is imported by packages within the ops-eng repo ie PyGithub imports PyJWT. By adding jwt to the requirements file it will install https://github.com/GehirnInc/python-jwt. The jwt package can cause a conflict at runtime. This ensure PyJWT is installed, allows moj_git_auth.py to import jwt and ensure the NotificationsAPIClient package uses PyJWT as well