### PR TITLE
Create a GitHub Action for report creation

### DIFF
--- a/.github/workflows/generate-github-standards-report.yaml
+++ b/.github/workflows/generate-github-standards-report.yaml
@@ -1,0 +1,26 @@
+name: Generate GitHub Standards Report
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  generate-github-standards-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: python3 -m pip install -r python/requirements.txt
+      - run: python3 -m python.scripts.report_on_repository_standards --oauth ${{ secrets.GH_BOT_PAT_TOKEN }} --org ministryofjustice --api-key ${{ secrets.REPORTS_API_KEY }}
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/python/scripts/report_on_repository_standards.py
+++ b/python/scripts/report_on_repository_standards.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 
 from python.services.github_service import GithubService
 from python.services.operations_engineering_reports import \
@@ -63,12 +62,8 @@ def main():
         args.oauth_token, args.org).fetch_all_repositories_in_org()
     repo_reports = [RepositoryReport(repo).output for repo in repos]
 
-    #  The database can't handle more than 100 at a time
-    # so we need to chunk the list into 100s.
-    api = reports_service(args.url, args.endpoint, args.api_key)
-    for i in range(0, len(repo_reports), 100):
-        chunk = repo_reports[i:i+100]
-        api.override_repository_standards_reports(chunk)
+    reports_service(args.url, args.endpoint, args.api_key). \
+        override_repository_standards_reports(repo_reports)
 
 
 if __name__ == "__main__":

--- a/python/scripts/report_on_repository_standards.py
+++ b/python/scripts/report_on_repository_standards.py
@@ -63,7 +63,7 @@ def main():
         args.oauth_token, args.org).fetch_all_repositories_in_org()
     repo_reports = [RepositoryReport(repo).output for repo in repos]
 
-    # The database can't handle more than 100 at a time
+    #  The database can't handle more than 100 at a time
     # so we need to chunk the list into 100s.
     api = reports_service(args.url, args.endpoint, args.api_key)
     for i in range(0, len(repo_reports), 100):

--- a/python/services/github_service.py
+++ b/python/services/github_service.py
@@ -476,7 +476,7 @@ class GithubService:
         after_cursor = None
         repos = []
 
-        # Disable logging. The output is too verbose and not required.
+        #  Disable logging. The output is too verbose and not required.
         logging.getLogger("gql").setLevel(logging.CRITICAL)
         logging.disable(logging.INFO)
 

--- a/python/services/github_service.py
+++ b/python/services/github_service.py
@@ -67,7 +67,7 @@ class GithubService:
         self.github_client_gql_api: Client = Client(transport=AIOHTTPTransport(
             url="https://api.github.com/graphql",
             headers={"Authorization": f"Bearer {org_token}"},
-        ), execute_timeout=200)
+        ), execute_timeout=120)
         self.organisation_name: str = organisation_name
         self.github_client_rest_api = Session()
         self.github_client_rest_api.headers.update(

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -45,4 +45,4 @@ class OperationsEngineeringReportsService:
 
         url = f"{self.__reports_url}/{self.__endpoint}"
 
-        return requests.post(url, headers=headers, json=data, timeout=30).status_code
+        return requests.post(url, headers=headers, json=data, timeout=120).status_code

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -31,10 +31,14 @@ class OperationsEngineeringReportsService:
             Exception: If the status code of the POST request is not 200.
 
         """
-        status = self.__http_post(reports)
-        if status != 200:
-            raise ValueError(
-                f"Failed to send repository standards reports to API. Received: {status}")
+        # The database can't handle more than 100 at a time
+        # so we need to chunk the list into 100s.
+        for i in range(0, len(reports), 100):
+            chunk = reports[i:i+100]
+            status = self.__http_post(chunk)
+            if status != 200:
+                raise ValueError(
+                    f"Failed to send repository standards reports to API. Received: {status}")
 
     def __http_post(self, data: list[dict]) -> int:
         headers = {

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -31,7 +31,7 @@ class OperationsEngineeringReportsService:
             Exception: If the status code of the POST request is not 200.
 
         """
-        # The database can't handle more than 100 at a time
+        #  The database can't handle more than 100 at a time
         # so we need to chunk the list into 100s.
         for i in range(0, len(reports), 100):
             chunk = reports[i:i+100]
@@ -50,7 +50,8 @@ class OperationsEngineeringReportsService:
         url = f"{self.__reports_url}/{self.__endpoint}"
 
         try:
-            resp = requests.post(url, headers=headers, json=data, timeout=120, stream=True).status_code
+            resp = requests.post(
+                url, headers=headers, json=data, timeout=120, stream=True).status_code
         except requests.exceptions.ChunkedEncodingError:
             resp = self.__http_post(data)
 

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -49,4 +49,9 @@ class OperationsEngineeringReportsService:
 
         url = f"{self.__reports_url}/{self.__endpoint}"
 
-        return requests.post(url, headers=headers, json=data, timeout=120).status_code
+        try:
+            resp = requests.post(url, headers=headers, json=data, timeout=120, stream=True).status_code
+        except requests.exceptions.ChunkedEncodingError:
+            resp = self.__http_post(data)
+
+        return resp


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/2243 and prepares the GitHub Standards Reports for a GitHub Action and public logging. 
- It removes the verbose logging from the graphql query.
- It creates an action to execute the Python script `report_on_repository_standards.py`.
- It removes some unwanted comments from the code base.
- After identifying an issue sending large chunks of reports to the reports API service, the dynamo db instance in the cloud platform cannot handle the write capacity. This is mitigated by chunking up the list of reports and sending them in batches of 100.