### PR TITLE
🚧 Remove slack message on failure; amend params

### DIFF
--- a/.github/workflows/generate-github-standards-report.yaml
+++ b/.github/workflows/generate-github-standards-report.yaml
@@ -14,13 +14,4 @@ jobs:
         with:
           python-version: "3.11"
       - run: python3 -m pip install -r python/requirements.txt
-      - run: python3 -m python.scripts.report_on_repository_standards --oauth ${{ secrets.GH_BOT_PAT_TOKEN }} --org ministryofjustice --api-key ${{ secrets.REPORTS_API_KEY }}
-      - name: Report failure to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "Failed GitHub Action Run"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - run: python3 -m python.scripts.report_on_repository_standards --oauth-token ${{ secrets.GH_BOT_PAT_TOKEN }} --api-key ${{ secrets.REPORTS_API_KEY }} --url https://operations-engineering-reports-prod.cloud-platform.service.justice.gov.uk --endpoint /api/v2/update-github-reports


### PR DESCRIPTION
To ensure this works as intended, this commit removes the noise when the action fails, it also adds the required parameters to make the script run.