### PR TITLE
Update archive repositories allow list

### DIFF
--- a/python/scripts/archive_repositories.py
+++ b/python/scripts/archive_repositories.py
@@ -19,7 +19,10 @@ MINISTRYOFJUSTICE_REPOS_ALLOW_LIST = [
     "jwt-laminas-auth",
     "laa-eric-emi",
     "hmpps-alfresco",
-    "yjaf-mule-mis-processor"
+    "yjaf-mule-mis-processor",
+    "satis-s3",
+    "wasm",
+    "wp-rewrite-media-to-s3"
 ]
 
 MOJ_ANALYTICAL_SERVICES_GITHUB_ORGANIZATION_NAME = "moj-analytical-services"


### PR DESCRIPTION
We have had a request to prevent archiving of the following repo's.  This PR will add them to them the allow list:

https://github.com/ministryofjustice/satis-s3
https://github.com/ministryofjustice/wasm
https://github.com/ministryofjustice/wp-rewrite-media-to-s3