### PR TITLE
📝 Add GitHub Feature Request Information

### DIFF
--- a/source/documentation/services/github-feature-request.html.md.erb
+++ b/source/documentation/services/github-feature-request.html.md.erb
@@ -1,0 +1,46 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Making Feature Requests to GitHub
+last_reviewed_on: 2023-08-01
+review_in: 3 months
+---
+
+# Making Feature Requests to GitHub
+
+At the Ministry of Justice, we encourage developers and analysts to suggest improvements and new features that could enhance their experience with GitHub. Here's how you can submit a feature request:
+
+## Step 1: Use the Issue Template
+
+Begin by navigating to the [operations-engineering](https://github.com/ministryofjustice/operations-engineering) repository and select the 'Issue' tab. Click on the 'New issue' button. Choose the `GitHub Feature Request` issue template. This template contains relevant fields for your request and will help us track it effectively.
+
+## Step 2: Define Your Feature Request
+
+Your request should take the form of a user story with defined acceptance criteria. This will help us understand the context and the value your feature would provide.
+
+```markdown
+As a [Your Role],
+I want [the feature or change],
+So that [benefit/value].
+```
+
+For example:
+
+```markdown
+As a Developer,
+I want to be able to deploy all of my code with a big red button,
+So that I can make my life easier.
+```
+
+## Step 3: Submit the Issue
+
+Fill out all the sections in the template, including the Acceptance Criteria and any additional notes or context. Then click 'Submit new issue'. This will automatically add relevant tags to your issue and place it on our `Third-Party Feature Requests Tracking` board on GitHub Projects.
+
+## Step 4: Track Your Feature Request
+
+You can now track the progress of your feature request through the [GitHub Projects board](https://github.com/orgs/ministryofjustice/projects/41). Our Operations Engineering team meets with a GitHub technical account manager monthly, and your request will be discussed in these meetings.
+
+We are here to make your experience with GitHub as productive and enjoyable as possible. If you have any questions or need any assistance, feel free to reach out to us via the #ask-operations-engineering Slack channel.
+
+We look forward to hearing your ideas and working to make them a reality!
+
+> Please replace `[Your Role]`, `[the feature or change]`, `[benefit/value]` with your actual role, the feature or change you want, and the benefit/value this feature or change will bring.

--- a/source/documentation/services/moj-github.html.md.erb
+++ b/source/documentation/services/moj-github.html.md.erb
@@ -46,6 +46,10 @@ As the custodians of these GitHub organisations, our team is responsible for the
 
 - **Account Automation:** We automate account management tasks like archiving inactive users and repositories, maintaining a clean and efficient workspace.
 
+## Making Feature Requests to GitHub
+
+We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [Making Feature Requests to GitHub Guide](https://operations-engineering.service.justice.gov.uk/documentation/services/making-feature-requests-to-github.html) for detailed instructions on how to submit your feature request and track its progress.
+
 ## How to Reach Us
 
 For any questions or support requests related to GitHub, don't hesitate to reach out. Contact us on the #ask-operations-engineering slack channel. We're here to help ensure your GitHub experience is smooth and productive.


### PR DESCRIPTION
Updated the GitHub Enterprise Management README to include a link to the newly created Feature Request Guide. This guide provides detailed instructions for developers and analysts on how to submit feature requests and track their progress. This new guide and updated link aim to facilitate better communication between the operations engineering team and developers or analysts seeking enhancements to GitHub. Also, improved the content of some sections for better understanding and clarity.
