### PR TITLE
📝 Add Runbook for Handling Third-Party GitHub Requests

### DIFF
--- a/source/documentation/runbooks.html.md.erb
+++ b/source/documentation/runbooks.html.md.erb
@@ -25,7 +25,6 @@ Documentation supporting day to day processes in the Operations Engineering team
 * [Domain Transfers for Non-gov.uk subdomains](runbooks/dns/domain-transfer.html)
 * [Redirecting Domains](runbooks/dns/dns-redirect.html)
 * [Delegation of Subdomains](runbooks/dns/domain-delegation.html)
-* [Handling GitHub Feature Requests](runbooks/services/handling-github-feature-requests.html)
 
 ## Services
 
@@ -42,6 +41,7 @@ Documentation supporting day to day processes in the Operations Engineering team
 * [Create An Auth0 Tenant](runbooks/services/create-an-auth0-tenant.html)
 * [Add a PagerDuty Slack Channel](runbooks/services/add-pagerduty-slack-channel.html)
 * [Request AWS Account Access](runbooks/services/aws-accounts.html)
+* [Handling GitHub Feature Requests](runbooks/services/handling-github-feature-requests.html)
 
 ### 1Password
 

--- a/source/documentation/runbooks.html.md.erb
+++ b/source/documentation/runbooks.html.md.erb
@@ -25,6 +25,7 @@ Documentation supporting day to day processes in the Operations Engineering team
 * [Domain Transfers for Non-gov.uk subdomains](runbooks/dns/domain-transfer.html)
 * [Redirecting Domains](runbooks/dns/dns-redirect.html)
 * [Delegation of Subdomains](runbooks/dns/domain-delegation.html)
+* [Handling GitHub Feature Requests](runbooks/services/handling-github-feature-requests.html)
 
 ## Services
 

--- a/source/documentation/runbooks/services/handling-github-feature-requests.html.md.erb
+++ b/source/documentation/runbooks/services/handling-github-feature-requests.html.md.erb
@@ -1,0 +1,40 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Handling Third-Party GitHub Requests
+last_reviewed_on: 2023-08-01
+review_in: 3 months
+---
+
+# Runbook: Handling Third-Party GitHub Requests
+
+## Objective:
+
+To provide a structured, efficient process for tracking and addressing third-party feature requests to GitHub.
+
+## Tools:
+
+- [Third-Party Feature Requests GitHub Project Board](https://github.com/orgs/ministryofjustice/projects/41/views/1)
+
+- Monthly meetings with GitHub's Technical Account Manager
+
+## Process:
+
+1. **Issue Creation**: Developers and analysts create new feature request issues using the provided issue template in the operations-engineering repository. The issue is automatically tagged and added to the GitHub Project Board.
+
+2. **Issue Status**: All new requests will be initially tagged as `New` on the GitHub Project Board. These are items that have not been discussed with GitHub yet.
+
+3. **Monthly Review Meeting**: The Operations Engineering team convenes a meeting with a GitHub Technical Account Manager once a month. The main agenda for this meeting is to review the items on the GitHub Project Board.
+
+4. **Check Progress**: At the meeting, the team first checks the progress of items that are already on the board. They review updates, discuss any roadblocks, and plan further action as necessary.
+
+5. **Raise New Items**: After reviewing the progress of ongoing items, the team then raises new items tagged as `New`. They discuss the nature of the request, its potential benefits, and the feasibility of implementing it.
+
+6. **Update Status**: After the meeting, the team updates the status of each item on the Project Board. Items might be moved from `New` to `In Progress`, `Complete`, or `Won't Do` based on the discussion.
+
+7. **Communication**: The team communicates the progress of each request back to the issue's originator. This can be a brief update on the issue thread or a more detailed conversation if required.
+
+## End of Process
+
+The cycle repeats each month to ensure continuous tracking and resolution of feature requests.
+
+Remember, our role is to facilitate and advocate for these requests. We aim to ensure that these requests are taken seriously by GitHub and addressed in a timely manner.

--- a/source/documentation/services/github-feature-request.html.md.erb
+++ b/source/documentation/services/github-feature-request.html.md.erb
@@ -1,0 +1,46 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Making Feature Requests to GitHub
+last_reviewed_on: 2023-08-01
+review_in: 3 months
+---
+
+# Making Feature Requests to GitHub
+
+At the Ministry of Justice, we encourage developers and analysts to suggest improvements and new features that could enhance their experience with GitHub. Here's how you can submit a feature request:
+
+## Step 1: Use the Issue Template
+
+Begin by navigating to the [operations-engineering](https://github.com/ministryofjustice/operations-engineering) repository and select the 'Issue' tab. Click on the 'New issue' button. Choose the `GitHub Feature Request` issue template. This template contains relevant fields for your request and will help us track it effectively.
+
+## Step 2: Define Your Feature Request
+
+Your request should take the form of a user story with defined acceptance criteria. This will help us understand the context and the value your feature would provide.
+
+```markdown
+As a [Your Role],
+I want [the feature or change],
+So that [benefit/value].
+```
+
+For example:
+
+```markdown
+As a Developer,
+I want to be able to deploy all of my code with a big red button,
+So that I can make my life easier.
+```
+
+## Step 3: Submit the Issue
+
+Fill out all the sections in the template, including the Acceptance Criteria and any additional notes or context. Then click 'Submit new issue'. This will automatically add relevant tags to your issue and place it on our `Third-Party Feature Requests Tracking` board on GitHub Projects.
+
+## Step 4: Track Your Feature Request
+
+You can now track the progress of your feature request through the [GitHub Projects board](https://github.com/orgs/ministryofjustice/projects/41). Our Operations Engineering team meets with a GitHub technical account manager monthly, and your request will be discussed in these meetings.
+
+We are here to make your experience with GitHub as productive and enjoyable as possible. If you have any questions or need any assistance, feel free to reach out to us via the #ask-operations-engineering Slack channel.
+
+We look forward to hearing your ideas and working to make them a reality!
+
+> Please replace `[Your Role]`, `[the feature or change]`, `[benefit/value]` with your actual role, the feature or change you want, and the benefit/value this feature or change will bring.

--- a/source/documentation/services/moj-github.html.md.erb
+++ b/source/documentation/services/moj-github.html.md.erb
@@ -46,6 +46,10 @@ As the custodians of these GitHub organisations, our team is responsible for the
 
 - **Account Automation:** We automate account management tasks like archiving inactive users and repositories, maintaining a clean and efficient workspace.
 
+## Making Feature Requests to GitHub
+
+We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [Making Feature Requests to GitHub Guide](https://operations-engineering.service.justice.gov.uk/documentation/services/making-feature-requests-to-github.html) for detailed instructions on how to submit your feature request and track its progress.
+
 ## How to Reach Us
 
 For any questions or support requests related to GitHub, don't hesitate to reach out. Contact us on the #ask-operations-engineering slack channel. We're here to help ensure your GitHub experience is smooth and productive.

--- a/source/documentation/services/moj-github.html.md.erb
+++ b/source/documentation/services/moj-github.html.md.erb
@@ -48,7 +48,7 @@ As the custodians of these GitHub organisations, our team is responsible for the
 
 ## Making Feature Requests to GitHub
 
-We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [Making Feature Requests to GitHub Guide](https://operations-engineering.service.justice.gov.uk/documentation/services/making-feature-requests-to-github.html) for detailed instructions on how to submit your feature request and track its progress.
+We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [Making Feature Requests to GitHub Guide](https://operations-engineering.service.justice.gov.uk/documentation/services/github-feature-request.html) for detailed instructions on how to submit your feature request and track its progress.
 
 ## How to Reach Us
 


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/3147/

Added a detailed runbook outlining the process by which the Operations Engineering team handles third-party feature requests to GitHub. 

The runbook details the monthly review process with GitHub's Technical Account Manager, the usage of the GitHub Project Board for tracking request statuses, and the communication process post-meeting. 

This will ensure a transparent, structured process for all involved parties.