### PR TITLE
⚡️  Add retry logic to HTTP POST requests

### DIFF
--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -11,7 +11,6 @@ class OperationsEngineeringReportsService:
         url {str} -- The url of the operations-engineering-reports API.
         endpoint {str} -- The endpoint of the operations-engineering-reports API.
         api_key {str} -- The API key to use for the operations-engineering-reports API.
-        enc_key {hex} -- The encryption key to use for the operations-engineering-reports API.
 
     """
 

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -62,6 +62,7 @@ class OperationsEngineeringReportsService:
         session.mount("http://", adapter)
         session.mount("https://", adapter)
 
-        resp = session.post(url, headers=headers, json=data, timeout=180, stream=True).status_code
+        resp = session.post(url, headers=headers, json=data,
+                            timeout=180, stream=True).status_code
 
         return resp

--- a/python/test/test_operations_engineering_report.py
+++ b/python/test/test_operations_engineering_report.py
@@ -22,13 +22,15 @@ class TestOperationsEngineeringReportsService(unittest.TestCase):
         )
 
         # Prepare the data for the test
-        test_data = [{'report_id': 1, 'data': 'report data 1'}, {'report_id': 2, 'data': 'report data 2'}]
+        test_data = [{'report_id': 1, 'data': 'report data 1'},
+                     {'report_id': 2, 'data': 'report data 2'}]
 
         # Call the method being tested
         service.override_repository_standards_reports(test_data)
 
         # Assertions
-        mock_session.assert_called_once()  # Ensure that the Session object is created once
+        # Ensure that the Session object is created once
+        mock_session.assert_called_once()
         mock_session.return_value.post.assert_called_once_with(
             'https://example.com/reports',
             headers={
@@ -56,15 +58,18 @@ class TestOperationsEngineeringReportsService(unittest.TestCase):
         )
 
         # Prepare the data for the test
-        test_data = [{'report_id': 1, 'data': 'report data 1'}, {'report_id': 2, 'data': 'report data 2'}]
+        test_data = [{'report_id': 1, 'data': 'report data 1'},
+                     {'report_id': 2, 'data': 'report data 2'}]
 
         # Call the method being tested, and expect an Exception to be raised
         with self.assertRaises(ValueError) as context:
             service.override_repository_standards_reports(test_data)
 
         # Assertions
-        mock_session.assert_called_once()  # Ensure that the Session object is created once
+        # Ensure that the Session object is created once
+        mock_session.assert_called_once()
         mock_session.return_value.post.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_operations_engineering_report.py
+++ b/python/test/test_operations_engineering_report.py
@@ -1,35 +1,70 @@
 import unittest
-from unittest.mock import patch
+from unittest import mock
 
 from python.services.operations_engineering_reports import \
     OperationsEngineeringReportsService
 
 
 class TestOperationsEngineeringReportsService(unittest.TestCase):
-    def setUp(self):
-        self.service = OperationsEngineeringReportsService(
-            'http://example.com', '/reports', 'api_key')
-        self.reports = [
-            {'repository': 'repo1', 'owner': 'owner1', 'compliant': True},
-            {'repository': 'repo2', 'owner': 'owner2', 'compliant': False}
-        ]
 
-    @patch('requests.post')
-    def test_override_repository_standards_reports(self, mock_post):
-        mock_post.return_value.status_code = 200
+    @mock.patch('python.services.operations_engineering_reports.requests.Session')
+    def test_override_repository_standards_reports_success(self, mock_session):
+        # Mock the response object and its status_code attribute
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_session.return_value.post.return_value = mock_response
 
-        self.service.override_repository_standards_reports(self.reports)
-        self.assertCountEqual(
-            mock_post.call_args[1]['json'], self.reports)
+        # Create an instance of the service
+        service = OperationsEngineeringReportsService(
+            url='https://example.com',
+            endpoint='reports',
+            api_key='test_api_key'
+        )
 
-    @patch('requests.post')
-    def test_override_repository_standards_reports_with_non_200(self, mock_post):
-        mock_post.return_value.status_code = 500
+        # Prepare the data for the test
+        test_data = [{'report_id': 1, 'data': 'report data 1'}, {'report_id': 2, 'data': 'report data 2'}]
 
-        with self.assertRaises(ValueError):
-            self.service.override_repository_standards_reports(self.reports)
-        mock_post.assert_called_once()
+        # Call the method being tested
+        service.override_repository_standards_reports(test_data)
 
+        # Assertions
+        mock_session.assert_called_once()  # Ensure that the Session object is created once
+        mock_session.return_value.post.assert_called_once_with(
+            'https://example.com/reports',
+            headers={
+                "Content-Type": "application/json",
+                "X-API-KEY": 'test_api_key',
+                "User-Agent": "reports-service-layer",
+            },
+            json=test_data,
+            timeout=180,
+            stream=True
+        )
+
+    @mock.patch('python.services.operations_engineering_reports.requests.Session')
+    def test_override_repository_standards_reports_failure(self, mock_session):
+        # Mock the response object and its status_code attribute
+        mock_response = mock.Mock()
+        mock_response.status_code = 500
+        mock_session.return_value.post.return_value = mock_response
+
+        # Create an instance of the service
+        service = OperationsEngineeringReportsService(
+            url='https://example.com',
+            endpoint='reports',
+            api_key='test_api_key'
+        )
+
+        # Prepare the data for the test
+        test_data = [{'report_id': 1, 'data': 'report data 1'}, {'report_id': 2, 'data': 'report data 2'}]
+
+        # Call the method being tested, and expect an Exception to be raised
+        with self.assertRaises(ValueError) as context:
+            service.override_repository_standards_reports(test_data)
+
+        # Assertions
+        mock_session.assert_called_once()  # Ensure that the Session object is created once
+        mock_session.return_value.post.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds retry logic to the `__http_post` method in the `ReportsService` class. The `Retry` object from the `requests` library is used to automatically retry failed requests up to 3 times, with a backoff factor of 1 second between retries.

The `status_forcelist` parameter is set to `[500, 502, 503, 504]` to retry requests that fail due to server errors. The `method_whitelist` parameter is set to `["POST"]` to retry only POST requests. This improves the reliability of the `ReportsService` class when making HTTP POST requests to the API.