### PR TITLE
📝  Add GitHub Notifications Management Guide

### DIFF
--- a/source/documentation/runbooks.html.md.erb
+++ b/source/documentation/runbooks.html.md.erb
@@ -42,6 +42,7 @@ Documentation supporting day to day processes in the Operations Engineering team
 * [Add a PagerDuty Slack Channel](runbooks/services/add-pagerduty-slack-channel.html)
 * [Request AWS Account Access](runbooks/services/aws-accounts.html)
 * [Handling GitHub Feature Requests](runbooks/services/handling-github-feature-requests.html)
+* [Managing GitHub Notifications](runbooks/services/managing-github-notifications.html)
 
 ### 1Password
 

--- a/source/documentation/runbooks/services/managing-github-notifications.html.md.erb
+++ b/source/documentation/runbooks/services/managing-github-notifications.html.md.erb
@@ -1,0 +1,62 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: Managing GitHub Notifications
+last_reviewed_on: 2023-08-03
+review_in: 3 months
+---
+
+# User Guide: Managing GitHub Notifications
+
+Notifications play a crucial role in keeping us updated with the activities related to our projects on GitHub. However, it can sometimes become overwhelming due to the sheer volume. Here's a guide to help you manage your GitHub notifications efficiently and reduce unnecessary noise.
+
+## Step 1: Understanding the Source of Notifications
+
+GitHub sends notifications based on your interactions and subscriptions on the platform. By default, you're subscribed to conversations when:
+
+- You've not disabled automatic watching for repositories or teams you've joined.
+
+- You're assigned to an issue or pull request.
+
+- You've opened a pull request or issue.
+
+- You've commented on a thread.
+
+- You've manually subscribed to a thread by clicking Watch or Subscribe.
+
+- Your username or team you're a member of is @mentioned.
+
+- You've changed the state of a thread, such as closing an issue or merging a pull request.
+
+## Step 2: Unsubscribe from Unwanted Notifications
+
+If you want to unsubscribe from certain conversations, you can:
+
+1. **Visit the Conversation:** Navigate to the specific issue, pull request, or gist that you're receiving notifications from.
+
+2. **Unsubscribe:** Look for the 'Unsubscribe' button on the right side of the conversation page and click it. This will prevent further notifications from this particular thread.
+
+## Step 3: Managing Repository Subscriptions
+
+To unsubscribe from a repository:
+
+1. **Visit the Repository:** Navigate to the main page of the repository.
+
+2. **Change Watch Status:** On the top right, you'll see a 'Watch' button. Click it and select 'Unwatch'. This prevents you from receiving notifications from this repository.
+
+## Step 4: Managing Default Subscriptions
+
+You can also control your default subscription settings:
+
+1. **Visit Your Settings:** Click your profile picture in the top right corner, then select 'Settings'.
+
+2. **Navigate to Notifications:** In the left sidebar, select 'Notifications'.
+
+3. **Configure Your Settings:** Here, you can control the default watching behavior, decide how you'd like to receive notifications, and customize your email preferences.
+
+Remember, you can also customize your notifications inbox to focus on the notifications you care most about, using filters, custom work-flows, and saving important notifications.
+
+It's important to manage your GitHub notifications to focus on what matters most and avoid being overwhelmed. Take some time to adjust these settings according to your needs.
+
+For more details, you can always refer to the official GitHub documentation on [Managing your subscriptions](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/managing-your-subscriptions) and [Configuring notifications](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications).
+
+If you're still receiving unwanted notifications, consider reviewing your email headers, which show the intended recipient. If you need any further assistance or have feedback or feature requests for notifications, consider using our #github-community discussion in slack.

--- a/source/documentation/services/moj-github.html.md.erb
+++ b/source/documentation/services/moj-github.html.md.erb
@@ -84,6 +84,14 @@ We only ask that requests related to access are kept to the [#ask-operations-eng
 
 We encourage developers and analysts to suggest improvements and new features to GitHub. Please visit the [Making Feature Requests to GitHub Guide](https://operations-engineering.service.justice.gov.uk/documentation/services/github-feature-request.html) for detailed instructions on how to submit your feature request and track its progress.
 
+## Managing GitHub Notifications
+
+It's crucial for productivity and sanity to keep the volume of notifications manageable. Given that the use of GitHub across our different projects can generate a large number of notifications, we've compiled a guide to help you control and manage your notifications effectively.
+
+This guide covers understanding the source, turning off default settings, email notification management, and some best practices to ensure that you don't miss any important updates. Visit our [Managing GitHub Notifications Guide](https://operations-engineering.service.justice.gov.uk/documentation/runbooks/services/managing-github-notifications.html) to learn more.
+
+Remember, effective management of your notifications can greatly enhance your GitHub experience by reducing unnecessary noise and focusing on the updates that matter most to you.
+
 ## How to Reach Us
 
 For any questions or support requests related to GitHub, don't hesitate to reach out. Contact us on the #ask-operations-engineering slack channel. We're here to help ensure your GitHub experience is smooth and productive.


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/3143 and introduces a new section in our GitHub Enterprise Management documentation. 

The section links to a comprehensive guide on managing GitHub notifications effectively. The aim is to help our developers and teams control their notification settings to reduce noise and focus on important updates. This should improve productivity and enhance the overall GitHub experience within our organisation.