### PR TITLE
Remove reference to LastPass

### DIFF
--- a/source/documentation/runbooks/internal/respond-to-leavers.html.md.erb
+++ b/source/documentation/runbooks/internal/respond-to-leavers.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#operations-engineering-alerts"
 title: Respond to leavers
-last_reviewed_on: 2023-05-12
+last_reviewed_on: 2023-08-17
 review_in: 3 months
 ---
 
@@ -65,9 +65,9 @@ If the user has a PagerDuty account, you should remove them from the [MoJ organi
 
 If the user has an Auth0 account, you should remove them from the [MoJ organisation](https://manage.auth0.com/dashboard/eu/moj-uk/).
 
-### LastPass/1Password
+### 1Password
 
-If the user has a LastPass/[1Password](https://ministryofjustice.1password.eu/signin?landing-page=%2Fhome) account, you should remove them from the organisation.
+If the user has a [1Password](https://ministryofjustice.1password.eu/signin?landing-page=%2Fhome) account, you should remove them from the organisation.
 
 ## Communicate to the rest of the team
 


### PR DESCRIPTION
As LastPass has been decommissioned we won't need to remove LastPass accounts when a user leave the MoJ.