### PR TITLE
Improve logging and add log level argument

### DIFF
--- a/python/scripts/report_on_repository_standards.py
+++ b/python/scripts/report_on_repository_standards.py
@@ -1,5 +1,6 @@
 import argparse
 
+import logging
 from python.services.github_service import GithubService
 from python.services.operations_engineering_reports import \
     OperationsEngineeringReportsService as reports_service
@@ -62,7 +63,7 @@ def main():
         args.oauth_token, args.org).fetch_all_repositories_in_org()
     repo_reports = [RepositoryReport(repo).output for repo in repos]
 
-    reports_service(args.url, args.endpoint, args.api_key). \
+    reports_service(args.url, args.endpoint, args.api_key, "INFO"). \
         override_repository_standards_reports(repo_reports)
 
 

--- a/python/scripts/report_on_repository_standards.py
+++ b/python/scripts/report_on_repository_standards.py
@@ -63,7 +63,7 @@ def main():
         args.oauth_token, args.org).fetch_all_repositories_in_org()
     repo_reports = [RepositoryReport(repo).output for repo in repos]
 
-    reports_service(args.url, args.endpoint, args.api_key, "INFO"). \
+    reports_service(args.url, args.endpoint, args.api_key). \
         override_repository_standards_reports(repo_reports)
 
 

--- a/python/services/github_service.py
+++ b/python/services/github_service.py
@@ -612,10 +612,8 @@ class GithubService:
         after_cursor = None
         repos = []
 
-        #  Disable logging. The output is too verbose and not required.
-        logging.getLogger("gql").setLevel(logging.CRITICAL)
-        logging.disable(logging.INFO)
-
+        # Specifically switch off logging for this query as it is very large and doesn't need to be logged
+        logging.disabled = True
         while has_next_page:
             data = self.get_paginated_list_of_repositories(after_cursor, 50)
 
@@ -630,6 +628,9 @@ class GithubService:
 
             has_next_page = data["organization"]["repositories"]["pageInfo"]["hasNextPage"]
             after_cursor = data["organization"]["repositories"]["pageInfo"]["endCursor"]
+
+        # Re-enable logging
+        logging.disabled = False
         return repos
 
     @retries_github_rate_limit_exception_at_next_reset_once

--- a/python/services/github_service.py
+++ b/python/services/github_service.py
@@ -616,7 +616,7 @@ class GithubService:
             list: A list of the organisation repos names
         """
         repos = []
-                  
+
         # Specifically switch off logging for this query as it is very large and doesn't need to be logged
         logging.disabled = True
 
@@ -635,7 +635,7 @@ class GithubService:
 
                 has_next_page = data["search"]["pageInfo"]["hasNextPage"]
                 after_cursor = data["search"]["pageInfo"]["endCursor"]
-                
+
         # Re-enable logging
         logging.disabled = False
         return repos

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -16,7 +16,7 @@ class OperationsEngineeringReportsService:
 
     """
 
-    def __init__(self, url: str, endpoint: str, api_key: str, log_level: str) -> None:
+    def __init__(self, url: str, endpoint: str, api_key: str, log_level="INFO") -> None:
         self.__reports_url = url
         self.__endpoint = endpoint
         self.__api_key = api_key

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -62,6 +62,7 @@ class OperationsEngineeringReportsService:
         }
 
         url = f"{self.__reports_url}/{self.__endpoint}"
+        self.logger.debug(f"Sending POST request to {url} with data: {len(data)} items")
 
         session = requests.Session()
         retry_strategy = Retry(
@@ -76,5 +77,8 @@ class OperationsEngineeringReportsService:
 
         resp = session.post(url, headers=headers, json=data,
                             timeout=180, stream=True).status_code
-
+        if resp != 200:
+            self.logger.error(f"Failed POST request to {url}. Received status: {resp}")
+        else:
+            self.logger.debug(f"Successful POST request to {url}")
         return resp

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -42,16 +42,19 @@ class OperationsEngineeringReportsService:
         """
         #  The database can't handle more than 100 at a time
         # so we need to chunk the list into 100s.
-        self.logger.info(f"Sending {len(reports)} repository standards reports to API.")
+        self.logger.info(
+            f"Sending {len(reports)} repository standards reports to API.")
         for i in range(0, len(reports), 100):
             chunk = reports[i:i+100]
             status = self.__http_post(chunk)
             if status != 200:
-                self.logger.error(f"Failed to send chunk starting from index {i}. Received status: {status}")
+                self.logger.error(
+                    f"Failed to send chunk starting from index {i}. Received status: {status}")
                 raise ValueError(
                     f"Failed to send repository standards reports to API. Received: {status}")
             else:
-                self.logger.debug(f"Successfully sent chunk starting from index {i}")
+                self.logger.debug(
+                    f"Successfully sent chunk starting from index {i}")
 
     def __http_post(self, data: list[dict]) -> int:
         headers = {
@@ -61,7 +64,8 @@ class OperationsEngineeringReportsService:
         }
 
         url = f"{self.__reports_url}/{self.__endpoint}"
-        self.logger.debug(f"Sending POST request to {url} with data: {len(data)} items")
+        self.logger.debug(
+            f"Sending POST request to {url} with data: {len(data)} items")
 
         session = requests.Session()
         retry_strategy = LoggingRetry(
@@ -77,7 +81,8 @@ class OperationsEngineeringReportsService:
         resp = session.post(url, headers=headers, json=data,
                             timeout=180, stream=True).status_code
         if resp != 200:
-            self.logger.error(f"Failed POST request to {url}. Received status: {resp}")
+            self.logger.error(
+                f"Failed POST request to {url}. Received status: {resp}")
         else:
             self.logger.debug(f"Successful POST request to {url}")
         return resp
@@ -85,5 +90,6 @@ class OperationsEngineeringReportsService:
 
 class LoggingRetry(Retry):
     def increment(self, *args, **kwargs):
-        self.logger.warning(f"Retrying request due to failure. Retry number: {self.total}")
+        self.logger.warning(
+            f"Retrying request due to failure. Retry number: {self.total}")
         super(LoggingRetry, self).increment(*args, **kwargs)

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -44,7 +44,7 @@ class OperationsEngineeringReportsService:
         """
         #  The database can't handle more than 100 at a time
         # so we need to chunk the list into 100s.
-        self.logger.info("fSending {len(reports)} repository standards reports to API.")
+        self.logger.info(f"Sending {len(reports)} repository standards reports to API.")
         for i in range(0, len(reports), 100):
             chunk = reports[i:i+100]
             status = self.__http_post(chunk)

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -24,9 +24,7 @@ class OperationsEngineeringReportsService:
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel(log_level)
         self.logger.info(
-            f"Initialised {self.__class__.__name__}  \
-            with url:  {self.__reports_url},  \
-            endpoint: {self.__endpoint}"
+            f"Initialised {self.__class__.__name__} with url:  {self.__reports_url}, endpoint: {self.__endpoint}"
         )
 
     def override_repository_standards_reports(self, reports: list[dict]) -> None:
@@ -87,5 +85,5 @@ class OperationsEngineeringReportsService:
 
 class LoggingRetry(Retry):
     def increment(self, *args, **kwargs):
-        self._logger.warning(f"Retrying request due to failure. Retry number: {self.total}")
+        self.logger.warning(f"Retrying request due to failure. Retry number: {self.total}")
         super(LoggingRetry, self).increment(*args, **kwargs)

--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -1,5 +1,6 @@
 import requests
 import logging
+
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -65,7 +66,7 @@ class OperationsEngineeringReportsService:
         self.logger.debug(f"Sending POST request to {url} with data: {len(data)} items")
 
         session = requests.Session()
-        retry_strategy = Retry(
+        retry_strategy = LoggingRetry(
             total=3,
             backoff_factor=1,
             status_forcelist=[500, 502, 503, 504],
@@ -82,3 +83,9 @@ class OperationsEngineeringReportsService:
         else:
             self.logger.debug(f"Successful POST request to {url}")
         return resp
+
+
+class LoggingRetry(Retry):
+    def increment(self, *args, **kwargs):
+        self._logger.warning(f"Retrying request due to failure. Retry number: {self.total}")
+        super(LoggingRetry, self).increment(*args, **kwargs)

--- a/python/test/test_operations_engineering_report.py
+++ b/python/test/test_operations_engineering_report.py
@@ -18,7 +18,8 @@ class TestOperationsEngineeringReportsService(unittest.TestCase):
         service = OperationsEngineeringReportsService(
             url='https://example.com',
             endpoint='reports',
-            api_key='test_api_key'
+            api_key='test_api_key',
+            log_level='DEBUG'
         )
 
         # Prepare the data for the test
@@ -54,7 +55,8 @@ class TestOperationsEngineeringReportsService(unittest.TestCase):
         service = OperationsEngineeringReportsService(
             url='https://example.com',
             endpoint='reports',
-            api_key='test_api_key'
+            api_key='test_api_key',
+            log_level='DEBUG'
         )
 
         # Prepare the data for the test


### PR DESCRIPTION
Overview
---
This PR addresses the lack of logging in the operations-engineering-reports service class and attempts to improve the visibility of failing POST calls to the API. By merging this PR into the service, we will have a better idea as to why the GitHub Action is falling and perhaps offer a more concrete solution.

Examples of failing workflows:
https://github.com/ministryofjustice/operations-engineering/actions/runs/6375823736