### PR TITLE
Fix reports for newer urllib3 syntax of "method_whitelist"

### DIFF
--- a/python/services/operations_engineering_reports.py
+++ b/python/services/operations_engineering_reports.py
@@ -72,7 +72,7 @@ class OperationsEngineeringReportsService:
             total=3,
             backoff_factor=1,
             status_forcelist=[500, 502, 503, 504],
-            method_whitelist=["POST"],
+            allowed_methods=["POST"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("http://", adapter)


### PR DESCRIPTION
Fixes the error [seen in the CI](https://github.com/ministryofjustice/operations-engineering/actions/runs/6477815363/job/17588607600):
```TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'```

`method_whitelist` was deprecated from urllib3==1.26.0 and removed in urllib3==2.0.0 (released April 2023) - see: https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#200-2023-04-26

urllib3 is one of the dependencies of 'responses' - it just asks for the latest 2.x.x version: https://github.com/psf/requests/blob/main/setup.py#L64 I'm not sure why this didn't shown up in April 🤷 