### PR TITLE
🔔 Create a triggered alarm for low GitHub licences (Under 10)

### DIFF
--- a/bin/alert_on_low_github_licences.py
+++ b/bin/alert_on_low_github_licences.py
@@ -1,0 +1,55 @@
+"""
+GitHub License Monitoring Script
+
+Purpose:
+--------
+This script monitors the number of available licenses in a GitHub Enterprise account. 
+It is designed to provide alerts when the license count falls below a 
+specified threshold. 
+"""
+
+import os
+from services.github_service import GithubService
+from services.slack_service import SlackService
+
+def low_theshold_triggered_message(remaining_licences):
+    msg = (
+    f"Hi team 👋, \n\n"
+    f"There are only {remaining_licences} \
+    GitHub licences remaining in the enterprise account. \n\n"
+    f"Please add more licences to the enterprise account. \n\n"
+    f"Thanks, \n\n"
+
+    "The GitHub Licence Alerting Bot"
+    )
+
+    return msg
+
+def alert_on_low_github_licences(threshold=10):
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token is None:
+        print("No GITHUB_TOKEN environment variable set")
+        exit(1)
+    slack_token = os.environ.get("SLACK_TOKEN")
+    if slack_token is None:
+        print("No SLACK_TOKEN environment variable set")
+        exit(1)
+
+    ORGANISATION = "ministryofjustice"
+    ENTERPRISE = "ministry-of-justice-uk"
+    SLACK_CHANNEL = "operations-engineering-alerts"
+
+    remaining_licences = GithubService(github_token, ORGANISATION, ENTERPRISE). \
+    get_remaining_licences()
+    trigger_alert = remaining_licences < threshold
+
+    if trigger_alert:
+        print("Low number of GitHub licences remaining, only %d remaining" \
+            % remaining_licences)
+
+        SlackService(slack_token). \
+        send_message_to_plaintext_channel_name\
+        (low_theshold_triggered_message(remaining_licences), SLACK_CHANNEL)
+        
+if __name__ == "__main__":
+    alert_on_low_github_licences(10)

--- a/bin/alert_on_low_github_licences.py
+++ b/bin/alert_on_low_github_licences.py
@@ -12,18 +12,20 @@ import os
 from services.github_service import GithubService
 from services.slack_service import SlackService
 
+
 def low_theshold_triggered_message(remaining_licences):
     msg = (
-    f"Hi team 👋, \n\n"
-    f"There are only {remaining_licences} \
+        f"Hi team 👋, \n\n"
+        f"There are only {remaining_licences} \
     GitHub licences remaining in the enterprise account. \n\n"
-    f"Please add more licences to the enterprise account. \n\n"
-    f"Thanks, \n\n"
+        f"Please add more licences to the enterprise account. \n\n"
+        f"Thanks, \n\n"
 
-    "The GitHub Licence Alerting Bot"
+        "The GitHub Licence Alerting Bot"
     )
 
     return msg
+
 
 def alert_on_low_github_licences(threshold=10):
     github_token = os.environ.get("GITHUB_TOKEN")
@@ -40,16 +42,17 @@ def alert_on_low_github_licences(threshold=10):
     SLACK_CHANNEL = "operations-engineering-alerts"
 
     remaining_licences = GithubService(github_token, ORGANISATION, ENTERPRISE). \
-    get_remaining_licences()
+        get_remaining_licences()
     trigger_alert = remaining_licences < threshold
 
     if trigger_alert:
-        print("Low number of GitHub licences remaining, only %d remaining" \
-            % remaining_licences)
+        print("Low number of GitHub licences remaining, only %d remaining"
+              % remaining_licences)
 
         SlackService(slack_token). \
-        send_message_to_plaintext_channel_name\
-        (low_theshold_triggered_message(remaining_licences), SLACK_CHANNEL)
-        
+            send_message_to_plaintext_channel_name(
+                low_theshold_triggered_message(remaining_licences), SLACK_CHANNEL)
+
+
 if __name__ == "__main__":
     alert_on_low_github_licences(10)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 toml
 boto3
-PyGithub == 1.58.0
+PyGithub == 2.1.1
 python-dateutil == 2.8.2
 gql
 aiohttp

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -67,7 +67,7 @@ class GithubService:
         return super(GithubService, cls).__new__(cls)
 
     def __init__(self, org_token: str, organisation_name: str,
-                 enterprise_name: str=ENTERPRISE_NAME) -> None:
+                 enterprise_name: str = ENTERPRISE_NAME) -> None:
         self.organisation_name: str = organisation_name
         self.enterprise_name: str = enterprise_name
 
@@ -1195,6 +1195,6 @@ class GithubService:
         Returns:
             int: The number of remaining licenses.
         """
-        licence = self.github_client_core_api.get_enterprise(self.enterprise_name).get_consumed_licenses()
+        licence = self.github_client_core_api.get_enterprise(
+            self.enterprise_name).get_consumed_licenses()
         return licence.total_seats_purchased - licence.total_seats_consumed
-

--- a/test/test_github_service.py
+++ b/test/test_github_service.py
@@ -111,7 +111,7 @@ class TestGithubServiceInit(unittest.TestCase):
         self.assertEqual(ORGANISATION_NAME,
                          github_service.organisation_name)
         self.assertEqual(ENTERPRISE_NAME,
-                        github_service.enterprise_name)
+                         github_service.enterprise_name)
 
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
@@ -1718,6 +1718,7 @@ class MockGithubIssue(MagicMock):
 
     def edit(self, assignees):
         self.assignees = assignees
+
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__", new=MagicMock)

--- a/test/test_low_github_licences.py
+++ b/test/test_low_github_licences.py
@@ -6,6 +6,7 @@ from bin.alert_on_low_github_licences import low_theshold_triggered_message, ale
 from services.github_service import GithubService
 from services.slack_service import SlackService
 
+
 class TestGithubLicenseAlerting(unittest.TestCase):
 
     def test_low_threshold_triggered_message(self):
@@ -18,14 +19,16 @@ class TestGithubLicenseAlerting(unittest.TestCase):
             "Thanks, \n\n"
             "The GitHub Licence Alerting Bot"
         )
-        self.assertEqual(low_theshold_triggered_message(remaining_licences), expected_message)
+        self.assertEqual(low_theshold_triggered_message(
+            remaining_licences), expected_message)
 
     @patch.object(GithubService, "__new__")
     @patch.object(SlackService, "__new__")
     @patch('os.environ')
     def test_alert_on_low_github_licences(self, mock_env, mock_slack_service, mock_github_service):
         """ Test the alerting functionality for low GitHub licenses. """
-        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GITHUB_TOKEN', 'SLACK_TOKEN'] else None
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in [
+            'GITHUB_TOKEN', 'SLACK_TOKEN'] else None
 
         mock_github_instance = MagicMock()
         mock_github_service.return_value = mock_github_instance
@@ -38,6 +41,6 @@ class TestGithubLicenseAlerting(unittest.TestCase):
 
         mock_slack_instance.send_message_to_plaintext_channel_name.assert_called()
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/test/test_low_github_licences.py
+++ b/test/test_low_github_licences.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from bin.alert_on_low_github_licences import low_theshold_triggered_message, alert_on_low_github_licences
+
+from services.github_service import GithubService
+from services.slack_service import SlackService
+
+class TestGithubLicenseAlerting(unittest.TestCase):
+
+    def test_low_threshold_triggered_message(self):
+        """ Test the message format for low threshold alert. """
+        remaining_licences = 5
+        expected_message = (
+            "Hi team 👋, \n\n"
+            "There are only 5     GitHub licences remaining in the enterprise account. \n\n"
+            "Please add more licences to the enterprise account. \n\n"
+            "Thanks, \n\n"
+            "The GitHub Licence Alerting Bot"
+        )
+        self.assertEqual(low_theshold_triggered_message(remaining_licences), expected_message)
+
+    @patch.object(GithubService, "__new__")
+    @patch.object(SlackService, "__new__")
+    @patch('os.environ')
+    def test_alert_on_low_github_licences(self, mock_env, mock_slack_service, mock_github_service):
+        """ Test the alerting functionality for low GitHub licenses. """
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GITHUB_TOKEN', 'SLACK_TOKEN'] else None
+
+        mock_github_instance = MagicMock()
+        mock_github_service.return_value = mock_github_instance
+        mock_github_instance.get_remaining_licences.return_value = 5
+
+        mock_slack_instance = MagicMock()
+        mock_slack_service.return_value = mock_slack_instance
+
+        alert_on_low_github_licences(10)
+
+        mock_slack_instance.send_message_to_plaintext_channel_name.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Overview
---

This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/3764 and is related to the requirement to alert when we fall below a certain number of GitHub licences/seats.