### PR TITLE
add github action seats

### DIFF
--- a/.github/workflows/check-for-low-github-seats.yaml
+++ b/.github/workflows/check-for-low-github-seats.yaml
@@ -1,0 +1,20 @@
+name: Alarm if the number of GitHub seats is low
+
+on:
+  schedule:
+    - cron: "0 6,12,16 * * *" # Runs daily at 0600, 1200 and 1600
+  workflow_dispatch:
+
+jobs:
+  low-seats-threshold:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: python3 -m pip install -r requirements.txt
+      - run: python3 -m bin.alert_on_low_github_licences
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_ENTERPRISE_DATA }}
+          SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
 name: Tests
 on:
+  workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-    
+    branches: ["main"]
+
 jobs:
   sonarcloud:
     name: Run Unit Tests
@@ -17,12 +18,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: Install tox
-        run: pip install tox
-      - name: Run tox
-        run: tox
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run coverage
+        run: |
+          pytest --cov-config=.coveragerc --cov=./ci_course --cov-report=xml
+          cat coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: coverage.xml


### PR DESCRIPTION
- :sparkles: Use codecov for test coverage
- :sparkles: Add a GitHub Action to alarm on low GitHub seats
