### PR TITLE
:wrench: Change the low GitHub seats slack message

### DIFF
--- a/bin/alert_on_low_github_licences.py
+++ b/bin/alert_on_low_github_licences.py
@@ -18,7 +18,9 @@ def low_theshold_triggered_message(remaining_licences):
         f"Hi team 👋, \n\n"
         f"There are only {remaining_licences} \
     GitHub licences remaining in the enterprise account. \n\n"
-        f"Please add more licences to the enterprise account. \n\n"
+        f"Please add more licences using the instructions outlined here: \n"
+        f"https://runbooks.operations-engineering.service.justice.gov.uk/documentation/internal/low-github-seats-procedure.html \n\n"
+
         f"Thanks, \n\n"
 
         "The GitHub Licence Alerting Bot"

--- a/test/test_low_github_licences.py
+++ b/test/test_low_github_licences.py
@@ -15,8 +15,11 @@ class TestGithubLicenseAlerting(unittest.TestCase):
         expected_message = (
             "Hi team 👋, \n\n"
             "There are only 5     GitHub licences remaining in the enterprise account. \n\n"
-            "Please add more licences to the enterprise account. \n\n"
-            "Thanks, \n\n"
+            f"Please add more licences using the instructions outlined here: \n"
+            f"https://runbooks.operations-engineering.service.justice.gov.uk/documentation/internal/low-github-seats-procedure.html \n\n"
+
+            f"Thanks, \n\n"
+
             "The GitHub Licence Alerting Bot"
         )
         self.assertEqual(low_theshold_triggered_message(


### PR DESCRIPTION
This includes the runbook instructions detailing how to act when the alarm is triggered.