### PR TITLE
🔧 Fix Set Standards not retaining existing required status checks

### DIFF
--- a/services/github_service.py
+++ b/services/github_service.py
@@ -427,7 +427,7 @@ class GithubService:
     def get_paginated_list_of_user_names_with_direct_access_to_repository(self, repository_name: str,
                                                                           after_cursor: str | None,
                                                                           page_size: int = GITHUB_GQL_DEFAULT_PAGE_SIZE) -> \
-        dict[str, Any]:
+            dict[str, Any]:
         logging.info(
             f"Getting paginated list of user names with direct access to repository {repository_name}. Page size {page_size}, after cursor {bool(after_cursor)}"
         )
@@ -605,7 +605,7 @@ class GithubService:
             if data["organization"]["repositories"]["edges"] is not None:
                 for repo in data["organization"]["repositories"]["edges"]:
                     if repo["node"]["isDisabled"] == True or repo["node"]["isArchived"] == True or repo["node"][
-                        "isLocked"] == True:
+                            "isLocked"] == True:
                         continue
                     repository_names.append(repo["node"]["name"])
 
@@ -725,7 +725,6 @@ class GithubService:
                                required_approving_review_count=1,
                                dismiss_stale_reviews=True,
                                )
-
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_paginated_list_of_repositories_per_topic(self, topic: str, after_cursor: str | None,
@@ -919,7 +918,7 @@ class GithubService:
     def _is_user_inactive(self, user: NamedUser.NamedUser, repositories: list[Repository],
                           inactivity_months: int) -> bool:
         cutoff_date = datetime.now() - timedelta(days=inactivity_months *
-                                                      30)  # Roughly calculate the cutoff date
+                                                 30)  # Roughly calculate the cutoff date
 
         for repo in repositories:
             # Get the user's commits in the repo

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -427,7 +427,7 @@ class GithubService:
     def get_paginated_list_of_user_names_with_direct_access_to_repository(self, repository_name: str,
                                                                           after_cursor: str | None,
                                                                           page_size: int = GITHUB_GQL_DEFAULT_PAGE_SIZE) -> \
-            dict[str, Any]:
+        dict[str, Any]:
         logging.info(
             f"Getting paginated list of user names with direct access to repository {repository_name}. Page size {page_size}, after cursor {bool(after_cursor)}"
         )
@@ -605,7 +605,7 @@ class GithubService:
             if data["organization"]["repositories"]["edges"] is not None:
                 for repo in data["organization"]["repositories"]["edges"]:
                     if repo["node"]["isDisabled"] == True or repo["node"]["isArchived"] == True or repo["node"][
-                            "isLocked"] == True:
+                        "isLocked"] == True:
                         continue
                     repository_names.append(repo["node"]["name"])
 
@@ -716,8 +716,16 @@ class GithubService:
             f"{self.organisation_name}/{repository_name}")
 
         repo.edit(has_issues=True)
-        repo.get_branch("main").edit_protection(
-            enforce_admins=True, required_approving_review_count=1, dismiss_stale_reviews=True)
+
+        branch = repo.get_branch("main")
+        current_protection = branch.get_protection()
+        branch.edit_protection(contexts=current_protection.required_status_checks.contexts,
+                               strict=current_protection.required_status_checks.strict,
+                               enforce_admins=True,
+                               required_approving_review_count=1,
+                               dismiss_stale_reviews=True,
+                               )
+
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_paginated_list_of_repositories_per_topic(self, topic: str, after_cursor: str | None,
@@ -911,7 +919,7 @@ class GithubService:
     def _is_user_inactive(self, user: NamedUser.NamedUser, repositories: list[Repository],
                           inactivity_months: int) -> bool:
         cutoff_date = datetime.now() - timedelta(days=inactivity_months *
-                                                 30)  # Roughly calculate the cutoff date
+                                                      30)  # Roughly calculate the cutoff date
 
         for repo in repositories:
             # Get the user's commits in the repo

--- a/test/test_github_service.py
+++ b/test/test_github_service.py
@@ -1288,6 +1288,7 @@ class TestGithubServiceFetchAllRepositories(unittest.TestCase):
         repos = github_service.fetch_all_repositories_in_org()
         self.assertEqual(len(repos), 0)
 
+
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__")
@@ -1845,13 +1846,13 @@ class TestReportOnInactiveUsers(unittest.TestCase):
 @patch("github.Github.__new__")
 class TestSetStandards(unittest.TestCase):
     def test_set_standards(self, mock_github_client_core_api: MagicMock):
-        mock_protection = Mock(required_status_checks=Mock(contexts=["test"], strict=True))
+        mock_protection = Mock(required_status_checks=Mock(
+            contexts=["test"], strict=True))
         mock_branch = Mock(Branch)
         mock_branch.get_protection.return_value = mock_protection
         mock_repo = MagicMock(Repository)
         mock_repo.get_branch.return_value = mock_branch
         mock_github_client_core_api.return_value.get_repo.return_value = mock_repo
-
 
         github_service = GithubService("", ORGANISATION_NAME)
         github_service.set_standards("test_repository")
@@ -1861,6 +1862,7 @@ class TestSetStandards(unittest.TestCase):
                                                        enforce_admins=True,
                                                        required_approving_review_count=1,
                                                        dismiss_stale_reviews=True, )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 👀 Purpose
- To fix a bug with the current implementation that was raised in https://github.com/ministryofjustice/operations-engineering/issues/3904 - where required status checks are removed for repositories that have the topic of `standards-compliant`

## ♻️ What's changed
- Added logic to retrieve the current required checks, and pass them through when we make the call to edit the protection rules

## 📝 Notes
- It should be noted that we may be modifying other fields as well, for example, if "number of approvers" is set to 2, we will amend this to 1. Our documentation is not clear about this. This process is potentially misconfiguring repositories where the team has set custom branch protection values.