### PR TITLE
🔧 Fix error when `required_status_checks` don't exist

### DIFF
--- a/services/github_service.py
+++ b/services/github_service.py
@@ -719,8 +719,8 @@ class GithubService:
 
         branch = repo.get_branch("main")
         current_protection = branch.get_protection()
-        branch.edit_protection(contexts=current_protection.required_status_checks.contexts,
-                               strict=current_protection.required_status_checks.strict,
+        branch.edit_protection(contexts=current_protection.required_status_checks.contexts or [],
+                               strict=current_protection.required_status_checks.strict or False,
                                enforce_admins=True,
                                required_approving_review_count=1,
                                dismiss_stale_reviews=True,


### PR DESCRIPTION
## 👀 Purpose
- To fix the scenario where a repository does not have required checks and provide some default blank values

## ♻️ What's changed
- added default values for when the required checks object is being read

## 📝 Notes
- Fixes issue caused in https://github.com/ministryofjustice/operations-engineering/pull/3909