### PR TITLE
🔧 Fix error when `required_status_checks` don't exist (attempt 2 with tests 🧪)

### DIFF
--- a/services/github_service.py
+++ b/services/github_service.py
@@ -719,12 +719,13 @@ class GithubService:
 
         branch = repo.get_branch("main")
         current_protection = branch.get_protection()
-        branch.edit_protection(contexts=current_protection.required_status_checks.contexts or [],
-                               strict=current_protection.required_status_checks.strict or False,
-                               enforce_admins=True,
-                               required_approving_review_count=1,
-                               dismiss_stale_reviews=True,
-                               )
+        branch.edit_protection(
+            contexts=current_protection.required_status_checks.contexts if current_protection.required_status_checks else [],
+            strict=current_protection.required_status_checks.strict if current_protection.required_status_checks else False,
+            enforce_admins=True,
+            required_approving_review_count=1,
+            dismiss_stale_reviews=True,
+        )
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_paginated_list_of_repositories_per_topic(self, topic: str, after_cursor: str | None,

--- a/test/test_github_service.py
+++ b/test/test_github_service.py
@@ -1863,6 +1863,23 @@ class TestSetStandards(unittest.TestCase):
                                                        required_approving_review_count=1,
                                                        dismiss_stale_reviews=True, )
 
+    def test_set_standards_handles_null_required_checks(self, mock_github_client_core_api: MagicMock):
+        mock_protection = Mock(required_status_checks=None)
+        mock_branch = Mock(Branch)
+        mock_branch.get_protection.return_value = mock_protection
+        mock_repo = MagicMock(Repository)
+        mock_repo.get_branch.return_value = mock_branch
+        mock_github_client_core_api.return_value.get_repo.return_value = mock_repo
+
+        github_service = GithubService("", ORGANISATION_NAME)
+        github_service.set_standards("test_repository")
+
+        mock_branch.edit_protection.assert_called_with(contexts=[],
+                                                       strict=False,
+                                                       enforce_admins=True,
+                                                       required_approving_review_count=1,
+                                                       dismiss_stale_reviews=True, )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 👀 Purpose
- To fix the scenario where a repository does not have required checks and provide some default blank values

## ♻️ What's changed
- added default values for when the required checks object is being read

## 📝 Notes
- Fixes issue caused in https://github.com/ministryofjustice/operations-engineering/pull/3909
- Initial attempt was in https://github.com/ministryofjustice/operations-engineering/pull/3911