### PR TITLE
🔥 Remove scheduling of archive repos whilst error is resolved

### DIFF
--- a/.github/workflows/archive-repos.yml
+++ b/.github/workflows/archive-repos.yml
@@ -2,8 +2,6 @@ name: Archive repo if over a certain date
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 12 * * 1-5"
 
 jobs:
   archive-repos:

--- a/.github/workflows/mojas-archive-repos.yml
+++ b/.github/workflows/mojas-archive-repos.yml
@@ -2,8 +2,6 @@ name: MoJ Analytical Services - Archive repo if over a certain date
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 12 * * 1-5"
 
 jobs:
   archive-repos:


### PR DESCRIPTION
## 👀 Purpose
- To reduce the noise caused by these jobs whilst the current exception being thrown is investigated and resolved

## ♻️ What's changed
- Removed the scheduling triggers from both workflows

## 📝 Notes
- Relates to https://github.com/ministryofjustice/operations-engineering/issues/3905