### PR TITLE
Replace tz info with None

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pyaml-env==1.2.1
 PyGithub==2.1.1
 PyJWT==2.8.0
 python-dateutil==2.8.2
+pytz==2023.3
 requests==2.31.0
 slack_sdk==3.26.0
 toml==0.10.2

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -104,7 +104,7 @@ class GithubService:
                 f"Manually check repository: {repository.name}. Reason: No commits in repository")
             return False
 
-        if commit.commit.author.date < last_active_cutoff_date:
+        if (commit.commit.author.date).replace(tzinfo=None) < (last_active_cutoff_date).replace(tzinfo=None):
             if repository.name in allow_list:
                 logging.info(
                     f"Skipping repository: {repository.name}. Reason: Present in allow list")

--- a/test_date_compare.py
+++ b/test_date_compare.py
@@ -1,0 +1,69 @@
+import os
+import unittest
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
+from pytz import timezone
+
+from unittest.mock import MagicMock, patch
+from freezegun import freeze_time
+
+from bin import archive_repositories
+
+class TestDateCompare(unittest.TestCase):
+
+
+    def test_tz_aware_compare_naive_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            tz_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London'))
+            tz_naive = datetime.now() - relativedelta(days=0, months=6, years=1)
+            tz_aware < tz_naive
+
+    
+    def test_aware_datetime_tzinfo_is_not_none(self):
+        tzinfo_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London')).tzinfo
+        print(tzinfo_aware)
+        message = "Timezone aware datetime timezone information is None."
+        self.assertIsNotNone(tzinfo_aware, message) 
+
+
+    def test_naive_datetime_tzinfo_is_none(self):
+        tzinfo_aware = datetime(2020, 5, 17).tzinfo
+        message = "Timezone naive datetime timezone is not None."
+        self.assertIsNone(tzinfo_aware, message) 
+
+
+    def test_tzinfo_not_equal_when_set_aware(self):
+        tzinfo_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London')).tzinfo
+        tzinfo_naive = datetime(2020, 5, 17).tzinfo
+        message = "Timezone information is not unequal."
+        self.assertNotEqual(tzinfo_aware, tzinfo_naive, message) 
+
+
+    def test_tzinfo_equal_when_aware_set_to_none(self):
+        removed_tzinfo_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London')).replace(tzinfo=None).tzinfo
+        tzinfo_naive = datetime(2020, 5, 17).tzinfo
+        message = "Timezone information is not equal."
+        self.assertEqual(removed_tzinfo_aware, tzinfo_naive, message)        
+
+
+    def test_tzinfo_not_equal(self):
+        tz_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London')).tzinfo
+        tz_naive = (datetime.now() - relativedelta(days=0, months=6, years=1)).tzinfo
+        message = "First value and second value are not unequal."
+        self.assertNotEqual(tz_aware, tz_naive, message)   
+
+
+    def test_tzinfo_equal_when_both_set_to_none(self):
+        removed_tzinfo_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London')).replace(tzinfo=None).tzinfo
+        removed_tzinfo_naive = (datetime.now() - relativedelta(days=0, months=6, years=1)).replace(tzinfo=None).tzinfo
+        message = "Timezone information is not equal."
+        self.assertEqual(removed_tzinfo_aware, removed_tzinfo_naive, message)   
+
+    def test_removing_tzinfo_ensures_comparable(self):
+        removed_tzinfo_aware = datetime(2020, 5, 17, tzinfo=timezone('Europe/London')).replace(tzinfo=None)
+        removed_tzinfo_naive = (datetime.now() - relativedelta(days=0, months=6, years=1)).replace(tzinfo=None)
+        message = "First value is not less that second value."
+        self.assertLess(removed_tzinfo_aware, removed_tzinfo_naive, message) 
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
To fix the comparison failure as described here #3905
This is due to trying to compare two datetimes in which one has timezone information (tz aware) and the other doesn't (tz naive).
Most likely the timezone information is being introduced from the GitHub (left hand) side of the inequality.
Fix wraps both sides with `(datetime object).replace(tzinfo=None)` to ensure universal naivety 😇