### PR TITLE
Reinstate archive repo workflow schedule

### DIFF
--- a/.github/workflows/archive-repos.yml
+++ b/.github/workflows/archive-repos.yml
@@ -2,6 +2,8 @@ name: Archive repo if over a certain date
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1-5"
 
 jobs:
   archive-repos:

--- a/.github/workflows/mojas-archive-repos.yml
+++ b/.github/workflows/mojas-archive-repos.yml
@@ -2,6 +2,8 @@ name: MoJ Analytical Services - Archive repo if over a certain date
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1-5"
 
 jobs:
   archive-repos:


### PR DESCRIPTION
Now that repo archiving workflows is fixed ([#3905](https://github.com/ministryofjustice/operations-engineering/issues/3905)) reinstate the workflows to their original schedule. 𐅐