### PR TITLE
:construction_worker: Add GitHub Action to trigger new owners check

### DIFF
--- a/.github/workflows/check-for-new-github-owners.yml
+++ b/.github/workflows/check-for-new-github-owners.yml
@@ -1,0 +1,33 @@
+
+name: Alarm if a new GitHub owner is added
+
+on:
+  schedule:
+    # Runs once a week on Monday at 1200
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+
+jobs:
+  check-for-new-github-owners:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: python3 -m pip install -r requirements.txt
+      - run: python3 -m bin.check_for_new_github_owners
+        env:
+          ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_AUDIT_LOG_TOKEN}}
+          ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
+
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to check for new GitHub owners"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/check-for-new-github-owners.yml
+++ b/.github/workflows/check-for-new-github-owners.yml
@@ -1,4 +1,3 @@
-
 name: Alarm if a new GitHub owner is added
 
 on:

--- a/bin/check_for_github_admins.py
+++ b/bin/check_for_github_admins.py
@@ -1,0 +1,58 @@
+import os
+from datetime import datetime, timedelta
+
+from services.github_service import GithubService
+from services.slack_service import SlackService
+
+
+def _calculate_date(in_last_days: int) -> str:
+    current_date = datetime.now()
+    date = current_date - timedelta(days=in_last_days)
+    timestamp_format = "%Y-%m-%d"
+    return date.strftime(timestamp_format)
+
+
+def new_owner_detected_message(new_owner, date_added, added_by, org, audit_log_url):
+    msg = (
+        f"Hi all, \n\n"
+        f"A new owner has been detected in the `{org}` GitHub org. \n\n"
+        f"*New owner:* {new_owner}\n"
+        f"*Date added:* {date_added}\n"
+        f"*By who:* {added_by}\n\n"
+
+        f"Please review the audit log for more details: {audit_log_url}\n\n"
+
+
+        f"Thanks, \n\n"
+
+        "The GitHub Organisation Monitoring Bot"
+    )
+
+    return msg
+
+
+def check_for_new_organisation_owners(in_last_days: int):
+    ORGINISATION = "ministryofjustice"
+    SLACK_CHANNEL = "operations-engineering-alerts"
+
+    audit_log_url = f"https://github.com/organizations/{ORGINISATION}/settings/audit-log?q=action%3Aorg.add_member++action%3Aorg.update_member"
+
+    admin_token = os.getenv("ADMIN_GITHUB_TOKEN")
+    slack_token = os.getenv("ADMIN_SLACK_TOKEN")
+    if not admin_token or not slack_token:
+        raise Exception("ADMIN_GITHUB_TOKEN and ADMIN_SLACK_TOKEN must be set")
+
+    gh = GithubService(str(admin_token), ORGINISATION)
+    slack = SlackService(str(slack_token))
+    changes = gh.flag_owner_permission_changes(_calculate_date(in_last_days))
+
+    if changes:
+        for change in changes:
+            message = new_owner_detected_message(
+                change["userLogin"], change["createdAt"], change["actorLogin"], ORGINISATION, audit_log_url)
+            slack.send_message_to_plaintext_channel_name(
+                message, SLACK_CHANNEL)
+
+
+if __name__ == "__main__":
+    check_for_new_organisation_owners(7)

--- a/test/test_github_service.py
+++ b/test/test_github_service.py
@@ -1940,7 +1940,6 @@ class TestNewOwnerDetected(unittest.TestCase):
 
     def test_flag_owner_permission_changes(self, mock_github_client_core_api):
         github_service = GithubService("", ORGANISATION_NAME)
-        # Mock the data returned by audit_log_member_changes
         mock_audit_log = [
             {'action': 'org.add_member', 'createdAt': '2023-12-06T10:32:07.832Z', 'actorLogin': 'testAdmin',
              'operationType': 'CREATE', 'permission': 'READ', 'userLogin': 'testUser'},

--- a/test/test_github_service.py
+++ b/test/test_github_service.py
@@ -1932,6 +1932,7 @@ class TestGithubServiceUpdateTeamRepositoryPermission(unittest.TestCase):
             github_service.update_team_repository_permission(
                 "dev-team", ["unknown-repo"], "write")
 
+
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__", new=MagicMock)
 @patch("services.github_service.Github")

--- a/test/test_github_service.py
+++ b/test/test_github_service.py
@@ -1,10 +1,11 @@
 import unittest
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import call, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 from freezegun import freeze_time
-from github import Github, GithubException, RateLimitExceededException, UnknownObjectException
+from github import (Github, GithubException, RateLimitExceededException,
+                    UnknownObjectException)
 from github.Branch import Branch
 from github.Commit import Commit
 from github.GitCommit import GitCommit
@@ -1930,6 +1931,57 @@ class TestGithubServiceUpdateTeamRepositoryPermission(unittest.TestCase):
         with self.assertRaises(ValueError):
             github_service.update_team_repository_permission(
                 "dev-team", ["unknown-repo"], "write")
+
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
+@patch("services.github_service.Github")
+class TestNewOwnerDetected(unittest.TestCase):
+
+    def test_flag_owner_permission_changes(self, mock_github_client_core_api):
+        github_service = GithubService("", ORGANISATION_NAME)
+        # Mock the data returned by audit_log_member_changes
+        mock_audit_log = [
+            {'action': 'org.add_member', 'createdAt': '2023-12-06T10:32:07.832Z', 'actorLogin': 'testAdmin',
+             'operationType': 'CREATE', 'permission': 'READ', 'userLogin': 'testUser'},
+            {'action': 'org.add_member', 'createdAt': '2023-12-06T10:33:07.832Z', 'actorLogin': 'johnsmith',
+             'operationType': 'CREATE', 'permission': 'ADMIN', 'userLogin': 'janedoe'}
+        ]
+        github_service.audit_log_member_changes = Mock(
+            return_value=mock_audit_log)
+
+        result = github_service.flag_owner_permission_changes("2023-12-01")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['action'], 'org.add_member')
+        self.assertEqual(result[0]['permission'], 'ADMIN')
+        self.assertEqual(result[0]['userLogin'], 'janedoe')
+
+    def test_audit_log_member_changes(self, mock_github_client_gql):
+        github_service = GithubService("", ORGANISATION_NAME)
+        return_value = {
+            "organization": {
+                "auditLog": {
+                    "edges": [
+                        {"node": {"action": "org.add_member", "createdAt": "2023-12-06T10:32:07.832Z",
+                                  "actorLogin": "user1", "permission": "READ"}},
+                        {"node": {"action": "org.update_member", "createdAt": "2023-12-06T10:33:07.832Z",
+                                  "actorLogin": "user2", "permission": "ADMIN"}}
+                    ],
+                    "pageInfo": {
+                        "endCursor": None,
+                        "hasNextPage": False
+                    }
+                }
+            }
+        }
+
+        github_service.github_client_gql_api.execute.return_value = return_value
+
+        result = github_service.audit_log_member_changes("2023-12-01")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['action'], 'org.add_member')
+        self.assertEqual(result[0]['permission'], 'READ')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/3760 and creates a weekly alarm that will inform the #operations-engineering slack channel of new GitHub "Owners".