### PR TITLE
👆 Bump Sentry Usage Alert Threshold

### DIFF
--- a/bin/sentry_usage_alert.py
+++ b/bin/sentry_usage_alert.py
@@ -16,7 +16,7 @@ def get_environment_variables() -> tuple[str, str, int, float]:
         raise ValueError("The env variable SLACK_TOKEN is empty or missing")
 
     period_in_days = os.getenv("PERIOD_IN_DAYS") or 1
-    usage_threshold = os.getenv("USAGE_THRESHOLD") or 60
+    usage_threshold = os.getenv("USAGE_THRESHOLD") or 80
 
     return sentry_token, slack_token, int(period_in_days), round(int(usage_threshold) / 100, 2)
 


### PR DESCRIPTION
## 👀 Purpose
- To lower the noise of these alerts (especially over the Christmas period), as high usage teams are struggling to deploy their changes to lower their sampling rates

## ♻️ What's changed
- Increased threshold form 60% to 80%

## 📝 Notes
- We should start investigating if any more teams in the top 10 or 20 may be able to reduce their usage faster
- 80% is probably as high as we want to go with the threshold, we should look at increasing the quota/being stricter with teams if we need to go any higher 