### PR TITLE
🔧 Fix some linting issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -416,6 +416,7 @@ disable=raw-checker-failed,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
+        missing-class-docstring,
         missing-module-docstring,
         missing-function-docstring,
         line-too-long

--- a/bin/alert_on_low_github_licences.py
+++ b/bin/alert_on_low_github_licences.py
@@ -3,17 +3,18 @@ GitHub License Monitoring Script
 
 Purpose:
 --------
-This script monitors the number of available licenses in a GitHub Enterprise account. 
-It is designed to provide alerts when the license count falls below a 
-specified threshold. 
+This script monitors the number of available licenses in a GitHub Enterprise account.
+It is designed to provide alerts when the license count falls below a
+specified threshold.
 """
 
 import os
+from config.constants import ENTERPRISE, MINISTRY_OF_JUSTICE, SLACK_CHANNEL
 from services.github_service import GithubService
 from services.slack_service import SlackService
 
 
-def low_theshold_triggered_message(remaining_licences):
+def low_threshold_triggered_message(remaining_licences):
     msg = (
         f"Hi team 👋, \n\n"
         f"There are only {remaining_licences} \
@@ -39,21 +40,17 @@ def alert_on_low_github_licences(threshold=10):
         print("No SLACK_TOKEN environment variable set")
         exit(1)
 
-    ORGANISATION = "ministryofjustice"
-    ENTERPRISE = "ministry-of-justice-uk"
-    SLACK_CHANNEL = "operations-engineering-alerts"
-
-    remaining_licences = GithubService(github_token, ORGANISATION, ENTERPRISE). \
-        get_remaining_licences()
+    remaining_licences = GithubService(
+        github_token, MINISTRY_OF_JUSTICE, ENTERPRISE).get_remaining_licences()
     trigger_alert = remaining_licences < threshold
 
     if trigger_alert:
-        print("Low number of GitHub licences remaining, only %d remaining"
-              % remaining_licences)
+        print(
+            f"Low number of GitHub licences remaining, only {remaining_licences} remaining")
 
         SlackService(slack_token). \
             send_message_to_plaintext_channel_name(
-                low_theshold_triggered_message(remaining_licences), SLACK_CHANNEL)
+                low_threshold_triggered_message(remaining_licences), SLACK_CHANNEL)
 
 
 if __name__ == "__main__":

--- a/bin/check_for_new_github_owners.py
+++ b/bin/check_for_new_github_owners.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta
+from config.constants import MINISTRY_OF_JUSTICE, SLACK_CHANNEL
 
 from services.github_service import GithubService
 from services.slack_service import SlackService
@@ -32,24 +33,21 @@ def new_owner_detected_message(new_owner, date_added, added_by, org, audit_log_u
 
 
 def check_for_new_organisation_owners(in_last_days: int):
-    ORGINISATION = "ministryofjustice"
-    SLACK_CHANNEL = "operations-engineering-alerts"
-
-    audit_log_url = f"https://github.com/organizations/{ORGINISATION}/settings/audit-log?q=action%3Aorg.add_member++action%3Aorg.update_member"
+    audit_log_url = f"https://github.com/organizations/{MINISTRY_OF_JUSTICE}/settings/audit-log?q=action%3Aorg.add_member++action%3Aorg.update_member"
 
     admin_token = os.getenv("ADMIN_GITHUB_TOKEN")
     slack_token = os.getenv("ADMIN_SLACK_TOKEN")
     if not admin_token or not slack_token:
         raise Exception("ADMIN_GITHUB_TOKEN and ADMIN_SLACK_TOKEN must be set")
 
-    gh = GithubService(str(admin_token), ORGINISATION)
+    gh = GithubService(str(admin_token), MINISTRY_OF_JUSTICE)
     slack = SlackService(str(slack_token))
     changes = gh.flag_owner_permission_changes(_calculate_date(in_last_days))
 
     if changes:
         for change in changes:
             message = new_owner_detected_message(
-                change["userLogin"], change["createdAt"], change["actorLogin"], ORGINISATION, audit_log_url)
+                change["userLogin"], change["createdAt"], change["actorLogin"], MINISTRY_OF_JUSTICE, audit_log_url)
             slack.send_message_to_plaintext_channel_name(
                 message, SLACK_CHANNEL)
 

--- a/bin/configure_standards.py
+++ b/bin/configure_standards.py
@@ -1,5 +1,5 @@
-from services.github_service import GithubService
 import os
+from services.github_service import GithubService
 
 
 def get_environment_variables() -> str:

--- a/bin/mass_permission_update.py
+++ b/bin/mass_permission_update.py
@@ -5,7 +5,7 @@ from services.github_service import GithubService
 
 
 def read_repository_list(file_path):
-    with open(file_path, 'r') as file:
+    with open(file=file_path, mode='r', encoding='utf-8') as file:
         return json.load(file)
 
 

--- a/bin/remove_collaborator_locked_repos.py
+++ b/bin/remove_collaborator_locked_repos.py
@@ -1,8 +1,6 @@
-from config.logging_config import logging
-
-from gql import gql
 import sys
-
+from gql import gql
+from config.logging_config import logging
 from services.github_service import GithubService
 
 
@@ -84,7 +82,7 @@ def fetch_repository_data(repository_name, github_service: GithubService) -> tup
     return collaborators_list, is_repository_locked
 
 
-class repository:
+class Repository:
     """A struct to store repository info ie name, collaborators, locked status"""
 
     name: str
@@ -123,7 +121,7 @@ def fetch_repositories(github_service: GithubService) -> list:
             repository_name, github_service
         )
         repositories_list.append(
-            repository(repository_name, collaborators_list,
+            Repository(repository_name, collaborators_list,
                        is_repository_locked)
         )
 

--- a/bin/report_on_repository_standards.py
+++ b/bin/report_on_repository_standards.py
@@ -1,6 +1,5 @@
 import argparse
 
-import logging
 from services.github_service import GithubService
 from services.operations_engineering_reports import \
     OperationsEngineeringReportsService as reports_service

--- a/bin/unowned_repositories.py
+++ b/bin/unowned_repositories.py
@@ -47,10 +47,10 @@ def get_unowned_repositories(github_service: GithubService) -> list:
                 if team_repository_name == repository_name and team["number_of_users"] > 0:
                     repository_has_team = True
                     break
-            if repository_has_team == True:
+            if repository_has_team is True:
                 break
 
-        if repository_has_team == False:
+        if repository_has_team is False:
             # Check repository has any outside collaborators
             if len(github_service.get_repository_collaborators(repository_name)) == 0:
                 # Repository has no owners

--- a/config/constants.py
+++ b/config/constants.py
@@ -5,3 +5,5 @@ MISSING_EMAIL_ADDRESS = "-"
 NO_ACTIVITY = "no activity"
 RESPONSE_OKAY = 200
 RESPONSE_NO_CONTENT = 204
+ENTERPRISE = "ministry-of-justice-uk"
+SLACK_CHANNEL = "operations-engineering-alerts"

--- a/services/metadata_service.py
+++ b/services/metadata_service.py
@@ -1,5 +1,5 @@
-import requests
 import logging
+import requests
 
 
 class MetadataService:
@@ -21,13 +21,13 @@ class MetadataService:
 
     def get_existing_slack_users(self):
         response = requests.get(
-            f"{self.api_url}/slack_users", headers={"Authorization": f"Bearer {self.api_token}"})
+            f"{self.api_url}/slack_users", headers={"Authorization": f"Bearer {self.api_token}"}, timeout=60)
         if response.status_code == 200:
             return response.json()
-        else:
-            logging.error(
-                "Error fetching existing Slack usernames: %s", response.content)
-            return []
+
+        logging.error(
+            "Error fetching existing Slack usernames: %s", response.content)
+        return []
 
     def filter_usernames(self, username_list: list[dict], accepted_username_list: list[dict]):
         """Filter out all usernames deemed not acceptable.
@@ -91,6 +91,7 @@ class MetadataService:
         response = requests.post(
             f"{self.api_url}/user/add",
             json=payload,
+            timeout=60
         )
 
         if response.status_code == 200 or response.status_code == 201:

--- a/services/slack_service.py
+++ b/services/slack_service.py
@@ -51,7 +51,7 @@ class SlackService:
                     channel_id = channel['id']
                     break
 
-        if channel_id == None and response['response_metadata']['next_cursor'] != '':
+        if channel_id is None and response['response_metadata']['next_cursor'] != '':
             channel_id = self._lookup_channel_id(
                 channel_name, cursor=response['response_metadata']['next_cursor'])
 

--- a/test/test_bin/test_low_github_licences.py
+++ b/test/test_bin/test_low_github_licences.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from bin.alert_on_low_github_licences import low_theshold_triggered_message, alert_on_low_github_licences
+from bin.alert_on_low_github_licences import low_threshold_triggered_message, alert_on_low_github_licences
 
 from services.github_service import GithubService
 from services.slack_service import SlackService
@@ -15,14 +15,14 @@ class TestGithubLicenseAlerting(unittest.TestCase):
         expected_message = (
             "Hi team 👋, \n\n"
             "There are only 5     GitHub licences remaining in the enterprise account. \n\n"
-            f"Please add more licences using the instructions outlined here: \n"
-            f"https://runbooks.operations-engineering.service.justice.gov.uk/documentation/internal/low-github-seats-procedure.html \n\n"
+            "Please add more licences using the instructions outlined here: \n"
+            "https://runbooks.operations-engineering.service.justice.gov.uk/documentation/internal/low-github-seats-procedure.html \n\n"
 
-            f"Thanks, \n\n"
+            "Thanks, \n\n"
 
             "The GitHub Licence Alerting Bot"
         )
-        self.assertEqual(low_theshold_triggered_message(
+        self.assertEqual(low_threshold_triggered_message(
             remaining_licences), expected_message)
 
     @patch.object(GithubService, "__new__")

--- a/test/test_bin/test_report_on_inactive_users.py
+++ b/test/test_bin/test_report_on_inactive_users.py
@@ -3,8 +3,6 @@ import unittest
 from unittest.mock import Mock, patch, MagicMock
 
 import bin.report_on_inactive_users as report_test
-from services.github_service import GithubService
-from services.slack_service import SlackService
 
 
 class TestReportOnInactiveUsers(unittest.TestCase):

--- a/test/test_bin/test_unowned_repositories.py
+++ b/test/test_bin/test_unowned_repositories.py
@@ -1,8 +1,5 @@
 import unittest
-import bin.dormant_users
 from unittest.mock import patch, MagicMock
-from services.slack_service import SlackService
-
 from bin.unowned_repositories import (
     main,
     get_cli_arguments,

--- a/test/test_services/test_metadata_service.py
+++ b/test/test_services/test_metadata_service.py
@@ -63,6 +63,7 @@ class TestMetadataService(unittest.TestCase):
         mock_post.assert_called_once_with(
             f"{self.api_url}/user/add",
             json={"users": usernames_to_add},
+            timeout=60
         )
 
     def test_add_new_usernames_api_error(self, mock_post):

--- a/test/test_services/test_operations_engineering_report.py
+++ b/test/test_services/test_operations_engineering_report.py
@@ -64,7 +64,7 @@ class TestOperationsEngineeringReportsService(unittest.TestCase):
                      {'report_id': 2, 'data': 'report data 2'}]
 
         # Call the method being tested, and expect an Exception to be raised
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValueError):
             service.override_repository_standards_reports(test_data)
 
         # Assertions

--- a/test/test_services/test_s3_service.py
+++ b/test/test_services/test_s3_service.py
@@ -8,8 +8,6 @@ from freezegun import freeze_time
 from services.s3_service import S3Service
 from config.constants import NO_ACTIVITY
 
-# pylint: disable=W0212, W0221, R6301, W0612
-
 
 class TestS3Service(unittest.TestCase):
     @patch("services.s3_service.boto3")


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/3953
- To align our codebase with some of our linting rules

## ♻️ What's changed

- Re-arranged and tidied up some imports
- Using `is` instead of `==` where it's safe and recommended
- Added timeouts to HTTP calls
- Added missing-class-docstring to ignore list in pylint
- Moved some constants into the constants file
- ...and a few other bits that I won't detail here

## 📝 Notes

- There are still a fair few errors, and will need to fix these (or ignore them) as we work through the code
- I stayed away from the GitHubService class, as it's a bit of beast - will probably need it's own PR