### PR TITLE
Create multiple repositories in test org using Terraform, which conform to moj standards

### DIFF
--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -74,7 +74,7 @@ jobs:
           ```
     
     - name: Terraform Apply
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       id: apply
       run: terraform apply -input=false -no-color -auto-approve
       continue-on-error: true

--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -77,4 +77,7 @@ jobs:
       # if: github.ref == 'refs/heads/main'
       id: apply
       run: terraform apply -input=false -no-color -auto-approve
-      continue-on-error: true
+
+    - name: Terraform Destroy
+      id: destroy
+      run: terraform destroy -input=false -no-color -auto-approve

--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -74,10 +74,6 @@ jobs:
           ```
     
     - name: Terraform Apply
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       id: apply
       run: terraform apply -input=false -no-color -auto-approve
-
-    - name: Terraform Destroy
-      id: destroy
-      run: terraform destroy -input=false -no-color -auto-approve

--- a/terraform/github/repositories/github-repos.tf
+++ b/terraform/github/repositories/github-repos.tf
@@ -23,8 +23,7 @@ locals {
 }
 
 module "operations_engineering_repositories" {
-  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories"
-  version = "0.0.1"
+  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories/releases/0.0.1"
 
   for_each = { for repository in local.operations_engineering_repositories : repository.name => repository }
 

--- a/terraform/github/repositories/github-repos.tf
+++ b/terraform/github/repositories/github-repos.tf
@@ -1,22 +1,37 @@
 locals {
   operations_engineering_repositories = {
 
-    "test-repository-levg1" = {
+    "test-repository-levg" = {
       name            = "test-repository-levg"
+      application_name = "test-repository-levg"
       description = "this repository was create by terraform managed by operations-engineering team"
       topics = ["github", "terraform", "operations-engineering"]
+      tags = {
+        Team = "operations-engineering"
+        Phase = "POC"
+      }
     }
 
     "test-repository-levg2" = {
       name            = "test-repository-levg2"
+      application_name = "test-repository-levg2"
       description = "this repository was create by terraform managed by operations-engineering team"
       topics = ["github", "terraform", "operations-engineering"]
+      tags = {
+        Team = "operations-engineering"
+        Phase = "POC"
+      }
     }
 
     "test-repository-levg3" = {
       name            = "test-repository-levg3"
+      application_name = "test-repository-levg3"
       description = "this repository was create by terraform managed by operations-engineering team"
       topics = ["github", "terraform", "operations-engineering"]
+      tags = {
+        Team = "operations-engineering"
+        Phase = "POC"
+      }
     }
 
   }
@@ -27,70 +42,9 @@ module "operations_engineering_repositories" {
 
   for_each = { for repository in local.operations_engineering_repositories : repository.name => repository }
 
-  name        = each.value.name
+  name = each.value.name
+  application_name = each.value.application_name
   description = each.value.description
-  topics      = lookup(each.value, "topics", [])
-  visibility  = lookup(each.value, "visibility", "public")
-
-  archived           = lookup(each.value, "archived", false)
-  archive_on_destroy = lookup(each.value, "archive_on_destroy", true)
-
-  is_template = lookup(each.value, "is_template", false)
-
-  use_template         = lookup(each.value, "use_template", true)
-  template_repository  = lookup(each.value, "template_repository", "template-repository")
-  has_discussions      = lookup(each.value, "has_discussions", false)
-  has_downloads        = lookup(each.value, "has_downloads", false)
-  has_issues           = lookup(each.value, "has_issues", true)
-  has_projects         = lookup(each.value, "has_projects", false)
-  has_wiki             = lookup(each.value, "has_wiki", false)
- 
-  vulnerability_alerts = lookup(each.value, "vulnerability_alerts", true)
-
-  auto_init = lookup(each.value, "auto_init", true)
-
-  allow_merge_commit   = lookup(each.value, "allow_merge_commit", false)
-  merge_commit_title   = lookup(each.value, "merge_commit_title", "MERGE_MESSAGE")
-  merge_commit_message = lookup(each.value, "merge_commit_message", "PR_TITLE")
-
-  allow_squash_merge          = lookup(each.value, "allow_squash_merge", true)
-  squash_merge_commit_title   = lookup(each.value, "squash_merge_commit_title", "PR_TITLE")
-  squash_merge_commit_message = lookup(each.value, "squash_merge_commit_message", "COMMIT_MESSAGES")
-
-  allow_update_branch    = lookup(each.value, "allow_update_branch", true)
-  allow_auto_merge       = lookup(each.value, "allow_auto_merge", false)
-  allow_rebase_merge     = lookup(each.value, "allow_rebase_merge", true)
-  delete_branch_on_merge = lookup(each.value, "delete_branch_on_merge", true)
-
-  pages_enabled       = lookup(each.value, "pages_enabled", false)
-  pages_configuration = lookup(each.value, "pages_configuration", null)
-
-  advanced_security_status               = lookup(each.value, "advanced_security_status", "enabled")
-  secret_scanning_status                 = lookup(each.value, "secret_scanning_status", "enabled")
-  secret_scanning_push_protection_status = lookup(each.value, "secret_scanning_push_protection_status", "enabled")
-
-  dependabot_security_updates_enabled = lookup(each.value, "dependabot_security_updates_enabled", true)
-
-  branch_protection_pattern                                                       = lookup(each.value, "branch_protection_pattern", "main")
-  branch_protection_allows_deletions                                              = lookup(each.value, "branch_protection_allows_deletions", false)
-  branch_protection_enforce_admins                                                = lookup(each.value, "branch_protection_enforce_admins", true)
-  branch_protection_force_push_bypassers                                          = lookup(each.value, "branch_protection_force_push_bypassers", [])
-  branch_protection_push_restrictions                                             = lookup(each.value, "branch_protection_push_restrictions", [])
-  branch_protection_require_signed_commits                                        = lookup(each.value, "branch_protection_require_signed_commits", false)
-  branch_protection_required_linear_history                                       = lookup(each.value, "branch_protection_required_linear_history", false)
-  branch_protection_require_conversation_resolution                               = lookup(each.value, "branch_protection_require_conversation_resolution", true)
-  branch_protection_allows_force_pushes                                           = lookup(each.value, "branch_protection_allows_force_pushes", false)
-  branch_protection_blocks_creations                                              = lookup(each.value, "branch_protection_blocks_creations", false)
-  branch_protection_lock_branch                                                   = lookup(each.value, "branch_protection_lock_branch", false)
-  branch_protection_required_pull_request_reviews_dismiss_stale_reviews           = lookup(each.value, "branch_protection_required_pull_request_reviews_dismiss_stale_reviews", true)
-  branch_protection_required_pull_request_reviews_restrict_dismissals             = lookup(each.value, "branch_protection_required_pull_request_reviews_restrict_dismissals", false)
-  branch_protection_required_pull_request_reviews_dismissal_restrictions          = lookup(each.value, "branch_protection_required_pull_request_reviews_dismissal_restrictions", [])
-  branch_protection_required_pull_request_reviews_pull_request_bypassers          = lookup(each.value, "branch_protection_required_pull_request_reviews_pull_request_bypassers", [])
-  branch_protection_required_pull_request_reviews_require_code_owner_reviews      = lookup(each.value, "branch_protection_required_pull_request_reviews_require_code_owner_reviews", true)
-  branch_protection_required_pull_request_reviews_require_last_push_approval      = lookup(each.value, "branch_protection_required_pull_request_reviews_require_last_push_approval", true)
-  branch_protection_required_pull_request_reviews_required_approving_review_count = lookup(each.value, "branch_protection_required_pull_request_reviews_required_approving_review_count", 1)
-  branch_protection_required_status_checks_strict                                 = lookup(each.value, "branch_protection_required_status_checks_strict", true)
-  branch_protection_required_status_checks_contexts                               = lookup(each.value, "branch_protection_required_status_checks_contexts", [])
-
-  access = lookup(each.value, "access", null)
+  topics = each.value.topics
+  tags = each.value.tags
 }

--- a/terraform/github/repositories/github-repos.tf
+++ b/terraform/github/repositories/github-repos.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 module "operations_engineering_repositories" {
-  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories/releases/0.0.1"
+  source = "https://github.com/ministryofjustice/operations-engineering-terraform-github-repositories/tree/0.0.1"
 
   for_each = { for repository in local.operations_engineering_repositories : repository.name => repository }
 

--- a/terraform/github/repositories/github-repos.tf
+++ b/terraform/github/repositories/github-repos.tf
@@ -2,7 +2,7 @@ locals {
   operations_engineering_repositories = {
 
     "test-repository-levg1" = {
-      name            = "test-repository-levg1"
+      name            = "test-repository-levg"
       description = "this repository was create by terraform managed by operations-engineering team"
       topics = ["github", "terraform", "operations-engineering"]
     }

--- a/terraform/github/repositories/github-repos.tf
+++ b/terraform/github/repositories/github-repos.tf
@@ -23,7 +23,7 @@ locals {
 }
 
 module "operations_engineering_repositories" {
-  source = "https://github.com/ministryofjustice/operations-engineering-terraform-github-repositories/tree/0.0.1"
+  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories"
 
   for_each = { for repository in local.operations_engineering_repositories : repository.name => repository }
 

--- a/terraform/github/repositories/github-repos.tf
+++ b/terraform/github/repositories/github-repos.tf
@@ -1,13 +1,97 @@
-module "repository" {
+locals {
+  operations_engineering_repositories = {
 
-  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories"
+    "test-repository-levg1" = {
+      name            = "test-repository-levg1"
+      description = "this repository was create by terraform managed by operations-engineering team"
+      topics = ["github", "terraform", "operations-engineering"]
+    }
 
-  application_name = "test-app-levg"
-  description = "this repository was create by terraform managed by operations-engineering team"
-  name = "test-repository-levg"
-  tags = {
-    Team = "operations-engineering"
-    Phase = "POC"
+    "test-repository-levg2" = {
+      name            = "test-repository-levg2"
+      description = "this repository was create by terraform managed by operations-engineering team"
+      topics = ["github", "terraform", "operations-engineering"]
+    }
+
+    "test-repository-levg3" = {
+      name            = "test-repository-levg3"
+      description = "this repository was create by terraform managed by operations-engineering team"
+      topics = ["github", "terraform", "operations-engineering"]
+    }
+
   }
-  topics = ["github", "terraform", "operations-engineering"]
+}
+
+module "operations_engineering_repositories" {
+  source = "github.com/ministryofjustice/operations-engineering-terraform-github-repositories"
+  version = "0.0.1"
+
+  for_each = { for repository in local.operations_engineering_repositories : repository.name => repository }
+
+  name        = each.value.name
+  description = each.value.description
+  topics      = lookup(each.value, "topics", [])
+  visibility  = lookup(each.value, "visibility", "public")
+
+  archived           = lookup(each.value, "archived", false)
+  archive_on_destroy = lookup(each.value, "archive_on_destroy", true)
+
+  is_template = lookup(each.value, "is_template", false)
+
+  use_template         = lookup(each.value, "use_template", true)
+  template_repository  = lookup(each.value, "template_repository", "template-repository")
+  has_discussions      = lookup(each.value, "has_discussions", false)
+  has_downloads        = lookup(each.value, "has_downloads", false)
+  has_issues           = lookup(each.value, "has_issues", true)
+  has_projects         = lookup(each.value, "has_projects", false)
+  has_wiki             = lookup(each.value, "has_wiki", false)
+ 
+  vulnerability_alerts = lookup(each.value, "vulnerability_alerts", true)
+
+  auto_init = lookup(each.value, "auto_init", true)
+
+  allow_merge_commit   = lookup(each.value, "allow_merge_commit", false)
+  merge_commit_title   = lookup(each.value, "merge_commit_title", "MERGE_MESSAGE")
+  merge_commit_message = lookup(each.value, "merge_commit_message", "PR_TITLE")
+
+  allow_squash_merge          = lookup(each.value, "allow_squash_merge", true)
+  squash_merge_commit_title   = lookup(each.value, "squash_merge_commit_title", "PR_TITLE")
+  squash_merge_commit_message = lookup(each.value, "squash_merge_commit_message", "COMMIT_MESSAGES")
+
+  allow_update_branch    = lookup(each.value, "allow_update_branch", true)
+  allow_auto_merge       = lookup(each.value, "allow_auto_merge", false)
+  allow_rebase_merge     = lookup(each.value, "allow_rebase_merge", true)
+  delete_branch_on_merge = lookup(each.value, "delete_branch_on_merge", true)
+
+  pages_enabled       = lookup(each.value, "pages_enabled", false)
+  pages_configuration = lookup(each.value, "pages_configuration", null)
+
+  advanced_security_status               = lookup(each.value, "advanced_security_status", "enabled")
+  secret_scanning_status                 = lookup(each.value, "secret_scanning_status", "enabled")
+  secret_scanning_push_protection_status = lookup(each.value, "secret_scanning_push_protection_status", "enabled")
+
+  dependabot_security_updates_enabled = lookup(each.value, "dependabot_security_updates_enabled", true)
+
+  branch_protection_pattern                                                       = lookup(each.value, "branch_protection_pattern", "main")
+  branch_protection_allows_deletions                                              = lookup(each.value, "branch_protection_allows_deletions", false)
+  branch_protection_enforce_admins                                                = lookup(each.value, "branch_protection_enforce_admins", true)
+  branch_protection_force_push_bypassers                                          = lookup(each.value, "branch_protection_force_push_bypassers", [])
+  branch_protection_push_restrictions                                             = lookup(each.value, "branch_protection_push_restrictions", [])
+  branch_protection_require_signed_commits                                        = lookup(each.value, "branch_protection_require_signed_commits", false)
+  branch_protection_required_linear_history                                       = lookup(each.value, "branch_protection_required_linear_history", false)
+  branch_protection_require_conversation_resolution                               = lookup(each.value, "branch_protection_require_conversation_resolution", true)
+  branch_protection_allows_force_pushes                                           = lookup(each.value, "branch_protection_allows_force_pushes", false)
+  branch_protection_blocks_creations                                              = lookup(each.value, "branch_protection_blocks_creations", false)
+  branch_protection_lock_branch                                                   = lookup(each.value, "branch_protection_lock_branch", false)
+  branch_protection_required_pull_request_reviews_dismiss_stale_reviews           = lookup(each.value, "branch_protection_required_pull_request_reviews_dismiss_stale_reviews", true)
+  branch_protection_required_pull_request_reviews_restrict_dismissals             = lookup(each.value, "branch_protection_required_pull_request_reviews_restrict_dismissals", false)
+  branch_protection_required_pull_request_reviews_dismissal_restrictions          = lookup(each.value, "branch_protection_required_pull_request_reviews_dismissal_restrictions", [])
+  branch_protection_required_pull_request_reviews_pull_request_bypassers          = lookup(each.value, "branch_protection_required_pull_request_reviews_pull_request_bypassers", [])
+  branch_protection_required_pull_request_reviews_require_code_owner_reviews      = lookup(each.value, "branch_protection_required_pull_request_reviews_require_code_owner_reviews", true)
+  branch_protection_required_pull_request_reviews_require_last_push_approval      = lookup(each.value, "branch_protection_required_pull_request_reviews_require_last_push_approval", true)
+  branch_protection_required_pull_request_reviews_required_approving_review_count = lookup(each.value, "branch_protection_required_pull_request_reviews_required_approving_review_count", 1)
+  branch_protection_required_status_checks_strict                                 = lookup(each.value, "branch_protection_required_status_checks_strict", true)
+  branch_protection_required_status_checks_contexts                               = lookup(each.value, "branch_protection_required_status_checks_contexts", [])
+
+  access = lookup(each.value, "access", null)
 }


### PR DESCRIPTION
Github repositories terraform module is used with a loop and map of test repositories to create multiple repositories in the test organization. 

Small changes have also been made, including removing redundant continue on fail declarations. 