### PR TITLE
Add support stats test csv

### DIFF
--- a/services/support_stats/test_sr_export.csv
+++ b/services/support_stats/test_sr_export.csv
@@ -1,0 +1,11 @@
+Request Type,Amount
+GitHub – add user to org,51
+DNS/Domain,14
+GitHub – add user to team/repo,11
+General infomation/help,9
+GitHub - add Renovate to repo,7
+Refer to another team,7
+,
+,
+Weekly Total,100
+Monthly Total,200


### PR DESCRIPTION
This PR is the initial setup to test using the existing GitHub to Slack integration to send a daily update regarding support requests volume to the Operations Engineering team Slack channel. 

- added a new folder under services 'support_stats' for the .csv file
- adds a test .csv file 'test_sr_export.csv'
