### PR TITLE
Update module version and address breaking changes

### DIFF
--- a/terraform/github/repositories/acronyms.tf
+++ b/terraform/github/repositories/acronyms.tf
@@ -1,9 +1,9 @@
 module "acronyms" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "acronyms"
-  application_name = "acronyms"
   description      = "List of abbreviations used within the MoJ, and their definitions"
   homepage_url     = "https://ministry-of-justice-acronyms.service.justice.gov.uk/"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/cloud-platform-maintenance-pages.tf
+++ b/terraform/github/repositories/cloud-platform-maintenance-pages.tf
@@ -1,8 +1,8 @@
 module "cloud-platform-maintenance-pages" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "cloud-platform-maintenance-pages"
-  application_name = "cloud-platform-maintenance-pages"
   description      = "Web application to serve gov.uk maintenance pages for multiple domains"
+  topics           = ["operations-engineering"]  
 }

--- a/terraform/github/repositories/github-actions.tf
+++ b/terraform/github/repositories/github-actions.tf
@@ -1,8 +1,8 @@
 module "github-actions" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "github-actions"
-  application_name = "github-actions"
   description      = "A github action which will run code formatters against PRs, and commit any resulting changes"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/github-collaborators.tf
+++ b/terraform/github/repositories/github-collaborators.tf
@@ -1,9 +1,9 @@
 module "github-collaborators" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "github-collaborators"
-  application_name = "github-collaborators"
   description      = "Manage outside collaborators on our Github repositories"
   has_discussions  = true
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/github.tf
+++ b/terraform/github/repositories/github.tf
@@ -1,8 +1,8 @@
 module "github" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = ".github"
-  application_name = ".github"
   description      = "Default organisational policies for the Ministry of Justice"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/moj-terraform-aws-sso.tf
+++ b/terraform/github/repositories/moj-terraform-aws-sso.tf
@@ -1,10 +1,9 @@
 module "moj-terraform-aws-sso" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   type             = "module"
   name             = "moj-terraform-aws-sso"
-  application_name = "moj-terraform-aws-sso"
   description      = "A Terraform module for setting up AWS SSO and Auth0, to allow users to sign-in to AWS using GitHub"
-  topics           = ["aws", "terraform", "iam", "sso", "terraform-module", "civil-service", "aws-sso"]
+  topics           = ["operations-engineering", "aws", "terraform", "iam", "sso", "terraform-module", "civil-service", "aws-sso"]
 }

--- a/terraform/github/repositories/moj-terraform-scim-github.tf
+++ b/terraform/github/repositories/moj-terraform-scim-github.tf
@@ -1,8 +1,8 @@
 module "moj-terraform-scim-github" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "moj-terraform-scim-github"
-  application_name = "moj-terraform-scim-github"
   description      = "Lambda function for automatic SCIM provisioning based on GitHub relationships"
+  topics           = ["operations-engineering"]  
 }

--- a/terraform/github/repositories/operations-engineering-certificate-renewal.tf
+++ b/terraform/github/repositories/operations-engineering-certificate-renewal.tf
@@ -1,8 +1,8 @@
 module "operations-engineering-certificate-renewal" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-certificate-renewal"
-  application_name = "operations-engineering-certificate-renewal"
   description      = "An application to automatically manage the renewal of certificates, and notify when certificates are close to expiring."
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/operations-engineering-devcontainer.tf
+++ b/terraform/github/repositories/operations-engineering-devcontainer.tf
@@ -1,8 +1,8 @@
 module "operations-engineering-devcontainer" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-devcontainer"
-  application_name = "operations-engineering-devcontainer"
   description      = ""
+  topics           = ["operations-engineering"]  
 }

--- a/terraform/github/repositories/operations-engineering-documentation-browser-extension.tf
+++ b/terraform/github/repositories/operations-engineering-documentation-browser-extension.tf
@@ -1,8 +1,8 @@
 module "operations-engineering-documentation-browser-extension" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-documentation-browser-extension"
-  application_name = "operations-engineering-documentation-browser-extension"
   description      = "A browser extension to easily find documentation for building MoJ Digital Services"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/operations-engineering-example.tf
+++ b/terraform/github/repositories/operations-engineering-example.tf
@@ -1,11 +1,11 @@
 module "operations-engineering-example" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-example"
-  application_name = "operations-engineering-example"
   description      = "Example application to showcase how to deploy code"
   homepage_url     = "https://operations-engineering-example-dev.cloud-platform.service.justice.gov.uk/"
+  topics           = ["operations-engineering"]  
   variables = {
     DEVELOPMENT_ECR_REGION     = var.ECR_REGION
     DEVELOPMENT_ECR_REPOSITORY = "operations-engineering/operations-engineering-example-dev"

--- a/terraform/github/repositories/operations-engineering-join-github.tf
+++ b/terraform/github/repositories/operations-engineering-join-github.tf
@@ -1,11 +1,11 @@
 module "operations-engineering-join-github" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-join-github"
-  application_name = "operations-engineering-join-github"
   description      = "An application to augment the process of joining a Ministry of Justice GitHub Organisation"
   homepage_url     = "https://join-github-dev.cloud-platform.service.justice.gov.uk/"
+  topics           = ["operations-engineering"]  
   variables = {
     DEV_ECR_REGION      = var.ECR_REGION
     DEV_ECR_REGISTRY    = var.ECR_REGISTRY

--- a/terraform/github/repositories/operations-engineering-metadata-poc.tf
+++ b/terraform/github/repositories/operations-engineering-metadata-poc.tf
@@ -1,10 +1,10 @@
 module "operations-engineering-metadata-poc" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-metadata-poc"
-  application_name = "operations-engineering-metadata-poc"
   description      = "PoC For Cross Identification Between MoJ Services"
+  topics           = ["operations-engineering"]  
   variables = {
     DEVELOPMENT_ECR_REGION     = var.ECR_REGION
     DEVELOPMENT_ECR_REPOSITORY = "operations-engineering/operations-engineering-metadata-poc-ecr"

--- a/terraform/github/repositories/operations-engineering-reports.tf
+++ b/terraform/github/repositories/operations-engineering-reports.tf
@@ -1,12 +1,11 @@
 module "operations-engineering-reports" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-reports"
-  application_name = "operations-engineering-reports"
   description      = "Web application to receive JSON data and display data in reports using HTML."
   homepage_url     = "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/"
-  topics           = ["flask", "reporting"]
+  topics           = ["operations-engineering", "flask", "reporting"]
   variables = {
     DEVELOPMENT_ECR_REGION     = var.ECR_REGION
     DEVELOPMENT_ECR_REPOSITORY = "operations-engineering/operations-engineering-reports-dev-ecr"

--- a/terraform/github/repositories/operations-engineering-runbooks.tf
+++ b/terraform/github/repositories/operations-engineering-runbooks.tf
@@ -1,10 +1,9 @@
 module "operations-engineering-runbooks" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-runbooks"
-  application_name = "operations-engineering-runbooks"
   description      = "Runbook documentation for Operations Engineering"
   homepage_url     = "https://runbooks.operations-engineering.service.justice.gov.uk/"
-  topics           = ["documentation"]
+  topics           = ["operations-engineering", "documentation"]
 }

--- a/terraform/github/repositories/operations-engineering-user-guide.tf
+++ b/terraform/github/repositories/operations-engineering-user-guide.tf
@@ -1,10 +1,9 @@
 module "operations-engineering-user-guide" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering-user-guide"
-  application_name = "operations-engineering-user-guide"
   description      = "User documentation for Operations Engineering"
   homepage_url     = "https://user-guide.operations-engineering.service.justice.gov.uk/"
-  topics           = ["documentation", "user-guides"]
+  topics           = ["operations-engineering", "documentation", "user-guides"]
 }

--- a/terraform/github/repositories/operations-engineering.tf
+++ b/terraform/github/repositories/operations-engineering.tf
@@ -1,11 +1,10 @@
 module "operations-engineering" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "operations-engineering"
-  application_name = "operations-engineering"
   description      = "This repository is home to the Operations Engineering's tools and utilities for managing, monitoring, and optimising software development processes at the Ministry of Justice."
   homepage_url     = "https://user-guide.operations-engineering.service.justice.gov.uk/"
   has_discussions  = true
-  topics           = ["python", "issue-tracker"]
+  topics           = ["operations-engineering", "python", "issue-tracker"]
 }

--- a/terraform/github/repositories/tech-docs-github-pages-publisher.tf
+++ b/terraform/github/repositories/tech-docs-github-pages-publisher.tf
@@ -1,9 +1,9 @@
 module "tech-docs-github-pages-publisher" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "tech-docs-github-pages-publisher"
-  application_name = "tech-docs-github-pages-publisher"
   description      = "Docker image to publish MoJ documentation repositories as github pages sites"
   homepage_url     = "https://hub.docker.com/r/ministryofjustice/tech-docs-github-pages-publisher"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/tech-docs-monitor.tf
+++ b/terraform/github/repositories/tech-docs-monitor.tf
@@ -1,8 +1,8 @@
 module "tech-docs-monitor" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "tech-docs-monitor"
-  application_name = "tech-docs-monitor"
   description      = "Part of alphagov/tech-docs-template (issues 👉https://github.com/alphagov/tech-docs-template/issues)"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/technical-guidance.tf
+++ b/terraform/github/repositories/technical-guidance.tf
@@ -1,9 +1,9 @@
 module "technical-guidance" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "technical-guidance"
-  application_name = "technical-guidance"
   description      = "How we build and operate products at the Ministry of Justice."
   homepage_url     = "https://technical-guidance.service.justice.gov.uk/"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/template-documentation-site.tf
+++ b/terraform/github/repositories/template-documentation-site.tf
@@ -1,10 +1,10 @@
 module "template-documentation-site" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "template-documentation-site"
-  application_name = "template-documentation-site"
   type             = "template"
   description      = "Template repo. for a gov.uk tech-docs-template documentation site published via github pages"
   homepage_url     = "https://ministryofjustice.github.io/template-documentation-site/"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/template-repository.tf
+++ b/terraform/github/repositories/template-repository.tf
@@ -1,9 +1,9 @@
 module "template-repository" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "template-repository"
-  application_name = "template-repository"
   type             = "template"
   description      = "Github \"template\" repository, from which to create new MoJ Repositories with organisation defaults"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/terraform-aws-mtasts.tf
+++ b/terraform/github/repositories/terraform-aws-mtasts.tf
@@ -1,9 +1,9 @@
 module "terraform-aws-mtasts" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "terraform-aws-mtasts"
-  application_name = "terraform-aws-mtasts"
   type             = "module"
   description      = "MTA-STS/TLS-RPT AWS Terraform Module"
+  topics           = ["operations-engineering"]
 }

--- a/terraform/github/repositories/terraform-github-repository.tf
+++ b/terraform/github/repositories/terraform-github-repository.tf
@@ -1,11 +1,10 @@
 module "terraform-github-repository" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "terraform-github-repository"
-  application_name = "terraform-github-repository"
   description      = "A Terraform module for GiHub repositories in the Ministry of Justice"
   has_discussions  = true
-  topics           = ["github", "terraform", "terraform-module"]
+  topics           = ["operations-engineering", "github", "terraform", "terraform-module"]
   type             = "module"
 }

--- a/terraform/github/repositories/terraform-template-poc.tf
+++ b/terraform/github/repositories/terraform-template-poc.tf
@@ -1,10 +1,9 @@
 module "terraform-template-poc" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
 
   name             = "terraform-template-poc"
-  application_name = "terraform-template-poc"
   type             = "template"
   description      = "A Proof of Concept for a resilient and scalable Terraform template, suitable for team use"
-  topics           = ["standards-compliant"]
+  topics           = ["operations-engineering", "standards-compliant"]
 }

--- a/terraform/github/repositories/test-repo-levg.tf
+++ b/terraform/github/repositories/test-repo-levg.tf
@@ -1,11 +1,11 @@
 module "test-repo-levg" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.4"
+  version = "0.0.6"
   providers = {
     github = github.ministryofjustice-test
   }
 
   name             = "test-repo-levg"
-  application_name = "test-repo-levg"
   description      = "test repo"
+  topics           = ["operations-engineering"]
 }


### PR DESCRIPTION
## 👀 Purpose

- Update the terraform files to use the latest version of the `ministryofjustice/repository/github` module

## ♻️ What's changed

For each of the 26 repositories
- 🎊 Update to use version 0.0.6 of the  `ministryofjustice/repository/github` module.
- 🔥 Remove references to redundant variable`application_name`.
- ♻️ Add `operations-engineering` topic as it is no longer set as a default.

## 📝 Notes

-