### PR TITLE
Test module team_access input

### DIFF
--- a/terraform/github/repositories/data.tf
+++ b/terraform/github/repositories/data.tf
@@ -1,0 +1,3 @@
+data "github_team" "operations_engineering" {
+  slug = "operations-engineering"
+}

--- a/terraform/github/repositories/data.tf
+++ b/terraform/github/repositories/data.tf
@@ -1,3 +1,7 @@
 data "github_team" "operations_engineering" {
   slug = "operations-engineering"
 }
+
+data "github_team" "operations_engineering_test" {
+  slug = "operations-engineering-test"
+}

--- a/terraform/github/repositories/data.tf
+++ b/terraform/github/repositories/data.tf
@@ -3,5 +3,6 @@ data "github_team" "operations_engineering" {
 }
 
 data "github_team" "operations_engineering_test" {
-  slug = "operations-engineering-test"
+  provider = github.ministryofjustice-test
+  slug     = "operations-engineering-test"
 }

--- a/terraform/github/repositories/test-tamf-repo-2.tf
+++ b/terraform/github/repositories/test-tamf-repo-2.tf
@@ -1,0 +1,10 @@
+module "test_tamf_repo_2" {
+  source = "github.com/ministryofjustice/terraform-github-repository.git?ref=add-team-option"
+
+  name        = "test-tamf-repo-2"
+  description = "Test repo to test new module input team_access"
+  topics      = ["operations-engineering"]
+  team_access = {
+    maintain = [data.github_team.operations_engineering.id]
+  }
+}

--- a/terraform/github/repositories/test-tamf-repo-test-org.tf
+++ b/terraform/github/repositories/test-tamf-repo-test-org.tf
@@ -1,0 +1,14 @@
+module "test_tamf_repo_test_org" {
+  source = "github.com/ministryofjustice/terraform-github-repository.git?ref=add-team-option"
+
+  providers = {
+    github = github.ministryofjustice-test
+  }
+
+  name        = "test-tamf-repo-test-org"
+  description = "Test repo to test new module input team_access"
+  topics      = ["operations-engineering"]
+  team_access = {
+    maintain = [data.github_team.operations_engineering_test.id]
+  }
+}


### PR DESCRIPTION
## 👀 Purpose

- Testing `team_access` input works for team in both `ministryofjustice` and `ministryofjustice-test` orgs.

## ♻️ What's changed

- `test-tamf-repo-2` to be created in `ministryofjustice` org with `operations-engineering` team associated as maintainers.
- `test-tamf-repo-test-org` to be created in `ministryofjustice-test` org with `operations-engineering-test` team associated as maintainers.

## 📝 Notes

-