### PR TITLE
✨ Update to input `team_access`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: v1.86.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate

--- a/terraform/github/repositories/acronyms.tf
+++ b/terraform/github/repositories/acronyms.tf
@@ -6,4 +6,8 @@ module "acronyms" {
   description  = "List of abbreviations used within the MoJ, and their definitions"
   homepage_url = "https://ministry-of-justice-acronyms.service.justice.gov.uk/"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/acronyms.tf
+++ b/terraform/github/repositories/acronyms.tf
@@ -1,6 +1,6 @@
 module "acronyms" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "acronyms"
   description  = "List of abbreviations used within the MoJ, and their definitions"

--- a/terraform/github/repositories/acronyms.tf
+++ b/terraform/github/repositories/acronyms.tf
@@ -6,8 +6,4 @@ module "acronyms" {
   description  = "List of abbreviations used within the MoJ, and their definitions"
   homepage_url = "https://ministry-of-justice-acronyms.service.justice.gov.uk/"
   topics       = ["operations-engineering"]
-
-  team_access = {
-    maintain = [data.github_team.operations_engineering.id]
-  }
 }

--- a/terraform/github/repositories/acronyms.tf
+++ b/terraform/github/repositories/acronyms.tf
@@ -6,4 +6,8 @@ module "acronyms" {
   description  = "List of abbreviations used within the MoJ, and their definitions"
   homepage_url = "https://ministry-of-justice-acronyms.service.justice.gov.uk/"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    maintain = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/cloud-platform-maintenance-pages.tf
+++ b/terraform/github/repositories/cloud-platform-maintenance-pages.tf
@@ -1,6 +1,6 @@
 module "cloud-platform-maintenance-pages" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "cloud-platform-maintenance-pages"
   description = "Web application to serve gov.uk maintenance pages for multiple domains"

--- a/terraform/github/repositories/cloud-platform-maintenance-pages.tf
+++ b/terraform/github/repositories/cloud-platform-maintenance-pages.tf
@@ -5,4 +5,8 @@ module "cloud-platform-maintenance-pages" {
   name        = "cloud-platform-maintenance-pages"
   description = "Web application to serve gov.uk maintenance pages for multiple domains"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/data.tf
+++ b/terraform/github/repositories/data.tf
@@ -6,3 +6,8 @@ data "github_team" "operations_engineering_test" {
   provider = github.ministryofjustice-test
   slug     = "operations-engineering-test"
 }
+
+data "github_team" "test_team_access" {
+  provider = github.ministryofjustice-test
+  slug     = "test-team-access"
+}

--- a/terraform/github/repositories/github-actions.tf
+++ b/terraform/github/repositories/github-actions.tf
@@ -5,4 +5,8 @@ module "github-actions" {
   name        = "github-actions"
   description = "A github action which will run code formatters against PRs, and commit any resulting changes"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/github-actions.tf
+++ b/terraform/github/repositories/github-actions.tf
@@ -1,6 +1,6 @@
 module "github-actions" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "github-actions"
   description = "A github action which will run code formatters against PRs, and commit any resulting changes"

--- a/terraform/github/repositories/github-collaborators.tf
+++ b/terraform/github/repositories/github-collaborators.tf
@@ -6,4 +6,8 @@ module "github-collaborators" {
   description     = "Manage outside collaborators on our Github repositories"
   has_discussions = true
   topics          = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/github-collaborators.tf
+++ b/terraform/github/repositories/github-collaborators.tf
@@ -1,6 +1,6 @@
 module "github-collaborators" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name            = "github-collaborators"
   description     = "Manage outside collaborators on our Github repositories"

--- a/terraform/github/repositories/github.tf
+++ b/terraform/github/repositories/github.tf
@@ -5,4 +5,8 @@ module "github" {
   name        = ".github"
   description = "Default organisational policies for the Ministry of Justice"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/github.tf
+++ b/terraform/github/repositories/github.tf
@@ -1,6 +1,6 @@
 module "github" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = ".github"
   description = "Default organisational policies for the Ministry of Justice"

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,5 +1,4 @@
 import {
-  provider = github.ministryofjustice-test
-  to       = module.test_tamf_repo_test_org.team_access.push
-  id       = data.github_team.test_team_access.id
+  to = module.test_tamf_repo_test_org.team_access.push
+  id = data.github_team.test_team_access.id
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -27,7 +27,7 @@ import {
 
 import {
   to = module.github.github_team_repository.admin["4192115"]
-  id = "4192115:github"
+  id = "4192115:.github"
 }
 
 import {

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,0 +1,5 @@
+import {
+  provider = github.ministryofjustice-test
+  to       = module.test_tamf_repo_test_org.team_access.push
+  id       = data.github_team.test_team_access.id
+}

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
 import {
-  to = module.repository.github.test_tamf_repo_test_org
-  id = data.github_team.test_team_access.id
+  to = module.test_tamf_repo_test_org.github_team_repository.push
+  id = "9472191"
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
 import {
-  to = module.test_tamf_repo_test_org
+  to = module.repository.github.test_tamf_repo_test_org["team_access"]
   id = data.github_team.test_team_access.id
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
 import {
-  to = module.test_tamf_repo_test_org.github_team_repository.push
-  id = "9472191"
+  to = module.test_tamf_repo_test_org.github_team_repository.push["9472191"]
+  id = "9472191:test-tamf-repo-test-org"
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -9,3 +9,8 @@ import {
   to = module.acronyms.github_team_repository.admin["4192115"]
   id = "4192115:acronyms"
 }
+
+import {
+  to = module.cloud-platform-maintenance-pages.github_team_repository.admin["4192115"]
+  id = "4192115:cloud-platform-maintenance-pages"
+}

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -6,6 +6,6 @@ import {
 
 # Imports to ministryofjustice operations-engineering team
 import {
-  to = module.test_tamf_repo_test_org.github_team_repository.admin["operations-engineering"]
+  to = module.acronyms.github_team_repository.admin["operations-engineering"]
   id = "operations-engineering:acronyms"
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
 import {
-  to = module.test_tamf_repo_test_org.team_access["push"]
+  to = module.test_tamf_repo_test_org
   id = data.github_team.test_team_access.id
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -4,8 +4,8 @@ import {
   id = "9472191:test-tamf-repo-test-org"
 }
 
-# Imports to ministryofjustice operations-engineering team
-# import {
-#   to = module.acronyms.github_team_repository.admin["operations-engineering"]
-#   id = "operations-engineering:acronyms"
-# }
+# Imports to ministryofjustice operations-engineering team_id 4192115 with admin access
+import {
+  to = module.acronyms.github_team_repository.admin["4192115"]
+  id = "4192115:acronyms"
+}

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
-import {
-  to = module.test_tamf_repo_test_org.team_access.push
-  id = data.github_team.test_team_access.id
-}
+# import {
+#   to = module.test_tamf_repo_test_org.team_access.push
+#   id = data.github_team.test_team_access.id
+# }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
 import {
-  to = module.repository.github.test_tamf_repo_test_org["team_access"]
+  to = module.repository.github.test_tamf_repo_test_org
   id = data.github_team.test_team_access.id
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -5,7 +5,7 @@ import {
 }
 
 # Imports to ministryofjustice operations-engineering team
-import {
-  to = module.acronyms.github_team_repository.admin["operations-engineering"]
-  id = "operations-engineering:acronyms"
-}
+# import {
+#   to = module.acronyms.github_team_repository.admin["operations-engineering"]
+#   id = "operations-engineering:acronyms"
+# }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,4 @@
-# import {
-#   to = module.test_tamf_repo_test_org.team_access.push
-#   id = data.github_team.test_team_access.id
-# }
+import {
+  to = module.test_tamf_repo_test_org.team_access["push"]
+  id = data.github_team.test_team_access.id
+}

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -5,12 +5,25 @@ import {
 }
 
 # Imports to ministryofjustice operations-engineering team_id 4192115 with admin access
-import {
-  to = module.acronyms.github_team_repository.admin["4192115"]
-  id = "4192115:acronyms"
+# import {
+#   to = module.acronyms.github_team_repository.admin["4192115"]
+#   id = "4192115:acronyms"
+# }
+
+# import {
+#   to = module.cloud-platform-maintenance-pages.github_team_repository.admin["4192115"]
+#   id = "4192115:cloud-platform-maintenance-pages"
+# }
+
+locals {
+  repositories = {
+    "acronyms"                         = "admin"
+    "cloud-platform-maintenance-pages" = "admin"
+  }
 }
 
 import {
-  to = module.cloud-platform-maintenance-pages.github_team_repository.admin["4192115"]
-  id = "4192115:cloud-platform-maintenance-pages"
+  for_each = local.repositories
+  to       = module.each.key.github_team_repository.each.value["4192115"]
+  id       = "4192115:${each.key}"
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,4 +1,11 @@
+# Imports to ministryofjustice-test org team_id 9472191
 import {
   to = module.test_tamf_repo_test_org.github_team_repository.push["9472191"]
   id = "9472191:test-tamf-repo-test-org"
+}
+
+# Imports to ministryofjustice operations-engineering team
+import {
+  to = module.test_tamf_repo_test_org.github_team_repository.admin["operations-engineering"]
+  id = "operations-engineering:acronyms"
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -1,29 +1,131 @@
-# Imports to ministryofjustice-test org team_id 9472191
+# Imports to ministryofjustice-test org team_id 9472191 with push access
 import {
   to = module.test_tamf_repo_test_org.github_team_repository.push["9472191"]
   id = "9472191:test-tamf-repo-test-org"
 }
 
 # Imports to ministryofjustice operations-engineering team_id 4192115 with admin access
-# import {
-#   to = module.acronyms.github_team_repository.admin["4192115"]
-#   id = "4192115:acronyms"
-# }
-
-# import {
-#   to = module.cloud-platform-maintenance-pages.github_team_repository.admin["4192115"]
-#   id = "4192115:cloud-platform-maintenance-pages"
-# }
-
-locals {
-  repositories = {
-    "acronyms"                         = "admin"
-    "cloud-platform-maintenance-pages" = "admin"
-  }
+import {
+  to = module.acronyms.github_team_repository.admin["4192115"]
+  id = "4192115:acronyms"
 }
 
 import {
-  for_each = local.repositories
-  to       = module.each.key.github_team_repository.each.value["4192115"]
-  id       = "4192115:${each.key}"
+  to = module.cloud-platform-maintenance-pages.github_team_repository.admin["4192115"]
+  id = "4192115:cloud-platform-maintenance-pages"
+}
+
+import {
+  to = module.github-actions.github_team_repository.admin["4192115"]
+  id = "4192115:github-actions"
+}
+
+import {
+  to = module.github-collaborators.github_team_repository.admin["4192115"]
+  id = "4192115:github-collaborators"
+}
+
+import {
+  to = module.github.github_team_repository.admin["4192115"]
+  id = "4192115:github"
+}
+
+import {
+  to = module.moj-terraform-aws-sso.github_team_repository.admin["4192115"]
+  id = "4192115:moj-terraform-aws-sso"
+}
+
+import {
+  to = module.moj-terraform-scim-github.github_team_repository.admin["4192115"]
+  id = "4192115:moj-terraform-scim-github"
+}
+
+import {
+  to = module.operations-engineering-certificate-renewal.github_team_repository.admin["4192115"]
+  id = "4192115:gitoperations-engineering-certificate-renewalhub"
+}
+
+import {
+  to = module.operations-engineering-devcontainer.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-devcontainer"
+}
+
+import {
+  to = module.operations-engineering-documentation-browser-extension.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-documentation-browser-extension"
+}
+
+import {
+  to = module.operations-engineering-example.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-example"
+}
+
+import {
+  to = module.operations-engineering-join-github.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-join-github"
+}
+
+import {
+  to = module.operations-engineering-metadata-poc.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-metadata-poc"
+}
+
+import {
+  to = module.operations-engineering-reports.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-reports"
+}
+
+import {
+  to = module.operations-engineering-runbooks.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-runbooks"
+}
+
+import {
+  to = module.operations-engineering-user-guide.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering-user-guide"
+}
+
+import {
+  to = module.operations-engineering.github_team_repository.admin["4192115"]
+  id = "4192115:operations-engineering"
+}
+
+import {
+  to = module.tech-docs-github-pages-publisher.github_team_repository.admin["4192115"]
+  id = "4192115:tech-docs-github-pages-publisher"
+}
+
+import {
+  to = module.tech-docs-monitor.github_team_repository.admin["4192115"]
+  id = "4192115:tech-docs-monitor"
+}
+
+import {
+  to = module.technical-guidance.github_team_repository.admin["4192115"]
+  id = "4192115:technical-guidance"
+}
+
+import {
+  to = module.template-documentation-site.github_team_repository.admin["4192115"]
+  id = "4192115:template-documentation-site"
+}
+
+import {
+  to = module.template-repository.github_team_repository.admin["4192115"]
+  id = "4192115:template-repository"
+}
+
+import {
+  to = module.terraform-aws-mtasts.github_team_repository.admin["4192115"]
+  id = "4192115:terraform-aws-mtasts"
+}
+
+import {
+  to = module.terraform-github-repository.github_team_repository.admin["4192115"]
+  id = "4192115:terraform-github-repository"
+}
+
+import {
+  to = module.terraform-template-poc.github_team_repository.admin["4192115"]
+  id = "4192115:terraform-template-poc"
 }

--- a/terraform/github/repositories/imports.tf
+++ b/terraform/github/repositories/imports.tf
@@ -42,7 +42,7 @@ import {
 
 import {
   to = module.operations-engineering-certificate-renewal.github_team_repository.admin["4192115"]
-  id = "4192115:gitoperations-engineering-certificate-renewalhub"
+  id = "4192115:operations-engineering-certificate-renewal"
 }
 
 import {

--- a/terraform/github/repositories/moj-terraform-aws-sso.tf
+++ b/terraform/github/repositories/moj-terraform-aws-sso.tf
@@ -1,6 +1,6 @@
 module "moj-terraform-aws-sso" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   type        = "module"
   name        = "moj-terraform-aws-sso"

--- a/terraform/github/repositories/moj-terraform-aws-sso.tf
+++ b/terraform/github/repositories/moj-terraform-aws-sso.tf
@@ -6,4 +6,8 @@ module "moj-terraform-aws-sso" {
   name        = "moj-terraform-aws-sso"
   description = "A Terraform module for setting up AWS SSO and Auth0, to allow users to sign-in to AWS using GitHub"
   topics      = ["operations-engineering", "aws", "terraform", "iam", "sso", "terraform-module", "civil-service", "aws-sso"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/moj-terraform-scim-github.tf
+++ b/terraform/github/repositories/moj-terraform-scim-github.tf
@@ -1,6 +1,6 @@
 module "moj-terraform-scim-github" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "moj-terraform-scim-github"
   description = "Lambda function for automatic SCIM provisioning based on GitHub relationships"

--- a/terraform/github/repositories/moj-terraform-scim-github.tf
+++ b/terraform/github/repositories/moj-terraform-scim-github.tf
@@ -5,4 +5,8 @@ module "moj-terraform-scim-github" {
   name        = "moj-terraform-scim-github"
   description = "Lambda function for automatic SCIM provisioning based on GitHub relationships"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering-certificate-renewal.tf
+++ b/terraform/github/repositories/operations-engineering-certificate-renewal.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-certificate-renewal" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "operations-engineering-certificate-renewal"
   description = "An application to automatically manage the renewal of certificates, and notify when certificates are close to expiring."

--- a/terraform/github/repositories/operations-engineering-certificate-renewal.tf
+++ b/terraform/github/repositories/operations-engineering-certificate-renewal.tf
@@ -5,4 +5,8 @@ module "operations-engineering-certificate-renewal" {
   name        = "operations-engineering-certificate-renewal"
   description = "An application to automatically manage the renewal of certificates, and notify when certificates are close to expiring."
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering-devcontainer.tf
+++ b/terraform/github/repositories/operations-engineering-devcontainer.tf
@@ -5,4 +5,8 @@ module "operations-engineering-devcontainer" {
   name        = "operations-engineering-devcontainer"
   description = ""
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering-devcontainer.tf
+++ b/terraform/github/repositories/operations-engineering-devcontainer.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-devcontainer" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "operations-engineering-devcontainer"
   description = ""

--- a/terraform/github/repositories/operations-engineering-documentation-browser-extension.tf
+++ b/terraform/github/repositories/operations-engineering-documentation-browser-extension.tf
@@ -5,4 +5,8 @@ module "operations-engineering-documentation-browser-extension" {
   name        = "operations-engineering-documentation-browser-extension"
   description = "A browser extension to easily find documentation for building MoJ Digital Services"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering-documentation-browser-extension.tf
+++ b/terraform/github/repositories/operations-engineering-documentation-browser-extension.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-documentation-browser-extension" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "operations-engineering-documentation-browser-extension"
   description = "A browser extension to easily find documentation for building MoJ Digital Services"

--- a/terraform/github/repositories/operations-engineering-example.tf
+++ b/terraform/github/repositories/operations-engineering-example.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-example" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "operations-engineering-example"
   description  = "Example application to showcase how to deploy code"

--- a/terraform/github/repositories/operations-engineering-example.tf
+++ b/terraform/github/repositories/operations-engineering-example.tf
@@ -6,6 +6,10 @@ module "operations-engineering-example" {
   description  = "Example application to showcase how to deploy code"
   homepage_url = "https://operations-engineering-example-dev.cloud-platform.service.justice.gov.uk/"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
   variables = {
     DEVELOPMENT_ECR_REGION     = var.ECR_REGION
     DEVELOPMENT_ECR_REPOSITORY = "operations-engineering/operations-engineering-example-dev"

--- a/terraform/github/repositories/operations-engineering-join-github.tf
+++ b/terraform/github/repositories/operations-engineering-join-github.tf
@@ -6,6 +6,10 @@ module "operations-engineering-join-github" {
   description  = "An application to augment the process of joining a Ministry of Justice GitHub Organisation"
   homepage_url = "https://join-github-dev.cloud-platform.service.justice.gov.uk/"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
   variables = {
     DEV_ECR_REGION      = var.ECR_REGION
     DEV_ECR_REGISTRY    = var.ECR_REGISTRY

--- a/terraform/github/repositories/operations-engineering-join-github.tf
+++ b/terraform/github/repositories/operations-engineering-join-github.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-join-github" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "operations-engineering-join-github"
   description  = "An application to augment the process of joining a Ministry of Justice GitHub Organisation"

--- a/terraform/github/repositories/operations-engineering-metadata-poc.tf
+++ b/terraform/github/repositories/operations-engineering-metadata-poc.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-metadata-poc" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "operations-engineering-metadata-poc"
   description = "PoC For Cross Identification Between MoJ Services"

--- a/terraform/github/repositories/operations-engineering-metadata-poc.tf
+++ b/terraform/github/repositories/operations-engineering-metadata-poc.tf
@@ -5,6 +5,10 @@ module "operations-engineering-metadata-poc" {
   name        = "operations-engineering-metadata-poc"
   description = "PoC For Cross Identification Between MoJ Services"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
   variables = {
     DEVELOPMENT_ECR_REGION     = var.ECR_REGION
     DEVELOPMENT_ECR_REPOSITORY = "operations-engineering/operations-engineering-metadata-poc-ecr"

--- a/terraform/github/repositories/operations-engineering-reports.tf
+++ b/terraform/github/repositories/operations-engineering-reports.tf
@@ -6,6 +6,10 @@ module "operations-engineering-reports" {
   description  = "Web application to receive JSON data and display data in reports using HTML."
   homepage_url = "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/"
   topics       = ["operations-engineering", "flask", "reporting"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
   variables = {
     DEVELOPMENT_ECR_REGION     = var.ECR_REGION
     DEVELOPMENT_ECR_REPOSITORY = "operations-engineering/operations-engineering-reports-dev-ecr"

--- a/terraform/github/repositories/operations-engineering-reports.tf
+++ b/terraform/github/repositories/operations-engineering-reports.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-reports" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "operations-engineering-reports"
   description  = "Web application to receive JSON data and display data in reports using HTML."

--- a/terraform/github/repositories/operations-engineering-runbooks.tf
+++ b/terraform/github/repositories/operations-engineering-runbooks.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-runbooks" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "operations-engineering-runbooks"
   description  = "Runbook documentation for Operations Engineering"

--- a/terraform/github/repositories/operations-engineering-runbooks.tf
+++ b/terraform/github/repositories/operations-engineering-runbooks.tf
@@ -6,4 +6,8 @@ module "operations-engineering-runbooks" {
   description  = "Runbook documentation for Operations Engineering"
   homepage_url = "https://runbooks.operations-engineering.service.justice.gov.uk/"
   topics       = ["operations-engineering", "documentation"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering-user-guide.tf
+++ b/terraform/github/repositories/operations-engineering-user-guide.tf
@@ -1,6 +1,6 @@
 module "operations-engineering-user-guide" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "operations-engineering-user-guide"
   description  = "User documentation for Operations Engineering"

--- a/terraform/github/repositories/operations-engineering-user-guide.tf
+++ b/terraform/github/repositories/operations-engineering-user-guide.tf
@@ -6,4 +6,8 @@ module "operations-engineering-user-guide" {
   description  = "User documentation for Operations Engineering"
   homepage_url = "https://user-guide.operations-engineering.service.justice.gov.uk/"
   topics       = ["operations-engineering", "documentation", "user-guides"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering.tf
+++ b/terraform/github/repositories/operations-engineering.tf
@@ -7,4 +7,8 @@ module "operations-engineering" {
   homepage_url    = "https://user-guide.operations-engineering.service.justice.gov.uk/"
   has_discussions = true
   topics          = ["operations-engineering", "python", "issue-tracker"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/operations-engineering.tf
+++ b/terraform/github/repositories/operations-engineering.tf
@@ -1,6 +1,6 @@
 module "operations-engineering" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name            = "operations-engineering"
   description     = "This repository is home to the Operations Engineering's tools and utilities for managing, monitoring, and optimising software development processes at the Ministry of Justice."

--- a/terraform/github/repositories/tech-docs-github-pages-publisher.tf
+++ b/terraform/github/repositories/tech-docs-github-pages-publisher.tf
@@ -1,6 +1,6 @@
 module "tech-docs-github-pages-publisher" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "tech-docs-github-pages-publisher"
   description  = "Docker image to publish MoJ documentation repositories as github pages sites"

--- a/terraform/github/repositories/tech-docs-github-pages-publisher.tf
+++ b/terraform/github/repositories/tech-docs-github-pages-publisher.tf
@@ -6,4 +6,8 @@ module "tech-docs-github-pages-publisher" {
   description  = "Docker image to publish MoJ documentation repositories as github pages sites"
   homepage_url = "https://hub.docker.com/r/ministryofjustice/tech-docs-github-pages-publisher"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/tech-docs-monitor.tf
+++ b/terraform/github/repositories/tech-docs-monitor.tf
@@ -5,4 +5,8 @@ module "tech-docs-monitor" {
   name        = "tech-docs-monitor"
   description = "Part of alphagov/tech-docs-template (issues 👉https://github.com/alphagov/tech-docs-template/issues)"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/tech-docs-monitor.tf
+++ b/terraform/github/repositories/tech-docs-monitor.tf
@@ -1,6 +1,6 @@
 module "tech-docs-monitor" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "tech-docs-monitor"
   description = "Part of alphagov/tech-docs-template (issues 👉https://github.com/alphagov/tech-docs-template/issues)"

--- a/terraform/github/repositories/technical-guidance.tf
+++ b/terraform/github/repositories/technical-guidance.tf
@@ -6,4 +6,8 @@ module "technical-guidance" {
   description  = "How we build and operate products at the Ministry of Justice."
   homepage_url = "https://technical-guidance.service.justice.gov.uk/"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/technical-guidance.tf
+++ b/terraform/github/repositories/technical-guidance.tf
@@ -1,6 +1,6 @@
 module "technical-guidance" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "technical-guidance"
   description  = "How we build and operate products at the Ministry of Justice."

--- a/terraform/github/repositories/template-documentation-site.tf
+++ b/terraform/github/repositories/template-documentation-site.tf
@@ -7,4 +7,8 @@ module "template-documentation-site" {
   description  = "Template repo. for a gov.uk tech-docs-template documentation site published via github pages"
   homepage_url = "https://ministryofjustice.github.io/template-documentation-site/"
   topics       = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/template-documentation-site.tf
+++ b/terraform/github/repositories/template-documentation-site.tf
@@ -1,6 +1,6 @@
 module "template-documentation-site" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name         = "template-documentation-site"
   type         = "template"

--- a/terraform/github/repositories/template-repository.tf
+++ b/terraform/github/repositories/template-repository.tf
@@ -1,6 +1,6 @@
 module "template-repository" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "template-repository"
   type        = "template"

--- a/terraform/github/repositories/template-repository.tf
+++ b/terraform/github/repositories/template-repository.tf
@@ -6,4 +6,8 @@ module "template-repository" {
   type        = "template"
   description = "Github \"template\" repository, from which to create new MoJ Repositories with organisation defaults"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/terraform-aws-mtasts.tf
+++ b/terraform/github/repositories/terraform-aws-mtasts.tf
@@ -1,6 +1,6 @@
 module "terraform-aws-mtasts" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "terraform-aws-mtasts"
   type        = "module"

--- a/terraform/github/repositories/terraform-aws-mtasts.tf
+++ b/terraform/github/repositories/terraform-aws-mtasts.tf
@@ -6,4 +6,8 @@ module "terraform-aws-mtasts" {
   type        = "module"
   description = "MTA-STS/TLS-RPT AWS Terraform Module"
   topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/terraform-github-repository.tf
+++ b/terraform/github/repositories/terraform-github-repository.tf
@@ -1,6 +1,6 @@
 module "terraform-github-repository" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name            = "terraform-github-repository"
   description     = "A Terraform module for GitHub repositories in the Ministry of Justice"

--- a/terraform/github/repositories/terraform-github-repository.tf
+++ b/terraform/github/repositories/terraform-github-repository.tf
@@ -7,4 +7,8 @@ module "terraform-github-repository" {
   has_discussions = true
   topics          = ["operations-engineering", "github", "terraform", "terraform-module"]
   type            = "module"
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/terraform-template-poc.tf
+++ b/terraform/github/repositories/terraform-template-poc.tf
@@ -1,6 +1,6 @@
 module "terraform-template-poc" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
 
   name        = "terraform-template-poc"
   type        = "template"

--- a/terraform/github/repositories/terraform-template-poc.tf
+++ b/terraform/github/repositories/terraform-template-poc.tf
@@ -6,4 +6,8 @@ module "terraform-template-poc" {
   type        = "template"
   description = "A Proof of Concept for a resilient and scalable Terraform template, suitable for team use"
   topics      = ["operations-engineering", "standards-compliant"]
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
 }

--- a/terraform/github/repositories/test-repo-levg.tf
+++ b/terraform/github/repositories/test-repo-levg.tf
@@ -1,6 +1,6 @@
 module "test-repo-levg" {
   source  = "ministryofjustice/repository/github"
-  version = "0.0.6"
+  version = "0.0.7"
   providers = {
     github = github.ministryofjustice-test
   }

--- a/terraform/github/repositories/test-tamf-repo-2.tf
+++ b/terraform/github/repositories/test-tamf-repo-2.tf
@@ -1,5 +1,6 @@
 module "test_tamf_repo_2" {
-  source = "github.com/ministryofjustice/terraform-github-repository.git?ref=add-team-option"
+  source  = "ministryofjustice/repository/github"
+  version = "0.0.7"
 
   name        = "test-tamf-repo-2"
   description = "Test repo to test new module input team_access"

--- a/terraform/github/repositories/test-tamf-repo-test-org.tf
+++ b/terraform/github/repositories/test-tamf-repo-test-org.tf
@@ -11,5 +11,6 @@ module "test_tamf_repo_test_org" {
   topics      = ["operations-engineering"]
   team_access = {
     maintain = [data.github_team.operations_engineering_test.id]
+    push     = [data.github_team.test_team_access.id]
   }
 }

--- a/terraform/github/repositories/test-tamf-repo-test-org.tf
+++ b/terraform/github/repositories/test-tamf-repo-test-org.tf
@@ -1,5 +1,6 @@
 module "test_tamf_repo_test_org" {
-  source = "github.com/ministryofjustice/terraform-github-repository.git?ref=add-team-option"
+  source  = "ministryofjustice/repository/github"
+  version = "0.0.7"
 
   providers = {
     github = github.ministryofjustice-test


### PR DESCRIPTION
## 👀 Purpose

- Update the terraform managed repositories to use latest version of the `terraform-github-repository` module.

## ♻️ What's changed

- ✨ Update `terraform-github-repository` module to version 0.0.7
- 🚀 Add `team_access` input for each repository to match existing teams and access level
- 🔨 Import existing GitHub team-repo associations

## 📝 Notes

-