### PR TITLE
Add repository definition for route 53 backup repository

### DIFF
--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -1,7 +1,6 @@
 name: "♻️ Terraform Github Repos"
 
 on:
-  workflow_dispatch:
   pull_request:
     paths:
       - "terraform/github/**"

--- a/terraform/github/repositories/teraform-aws-route53-backup.tf
+++ b/terraform/github/repositories/teraform-aws-route53-backup.tf
@@ -3,7 +3,7 @@ module "teraform-aws-route53-backup" {
   version = "0.0.8"
 
   name            = "teraform-aws-route53-backup"
-  description     = "A Terraform module for backup and restore of Amazon Route 53 records."
+  description     = "A Terraform module for backup and restoration of Amazon Route 53 records."
   has_discussions = true
   topics          = ["operations-engineering", "terraform", "terraform-module"]
   type            = "module"

--- a/terraform/github/repositories/teraform-aws-route53-backup.tf
+++ b/terraform/github/repositories/teraform-aws-route53-backup.tf
@@ -2,12 +2,12 @@ module "teraform-aws-route53-backup" {
   source  = "ministryofjustice/repository/github"
   version = "0.0.8"
 
-  name              = "teraform-aws-route53-backup"
-  description       = "A Terraform module for baclkup and restore of Amazon Route 53 records."
-  has_discussions   = true
-  topics            = ["operations-engineering", "terraform", "terraform-module"]
-  type              = "module"
-  visibilvisibility = "internal"
+  name            = "teraform-aws-route53-backup"
+  description     = "A Terraform module for baclkup and restore of Amazon Route 53 records."
+  has_discussions = true
+  topics          = ["operations-engineering", "terraform", "terraform-module"]
+  type            = "module"
+  visibility      = "internal"
 
   team_access = {
     admin = [data.github_team.operations_engineering.id]

--- a/terraform/github/repositories/teraform-aws-route53-backup.tf
+++ b/terraform/github/repositories/teraform-aws-route53-backup.tf
@@ -3,7 +3,7 @@ module "teraform-aws-route53-backup" {
   version = "0.0.8"
 
   name            = "teraform-aws-route53-backup"
-  description     = "A Terraform module for baclkup and restore of Amazon Route 53 records."
+  description     = "A Terraform module for backup and restore of Amazon Route 53 records."
   has_discussions = true
   topics          = ["operations-engineering", "terraform", "terraform-module"]
   type            = "module"

--- a/terraform/github/repositories/teraform-aws-route53-backup.tf
+++ b/terraform/github/repositories/teraform-aws-route53-backup.tf
@@ -1,0 +1,15 @@
+module "teraform-aws-route53-backup" {
+  source  = "ministryofjustice/repository/github"
+  version = "0.0.8"
+
+  name              = "teraform-aws-route53-backup"
+  description       = "A Terraform module for baclkup and restore of Amazon Route 53 records."
+  has_discussions   = true
+  topics            = ["operations-engineering", "terraform", "terraform-module"]
+  type              = "module"
+  visibilvisibility = "internal"
+
+  team_access = {
+    admin = [data.github_team.operations_engineering.id]
+  }
+}

--- a/terraform/github/repositories/terraform-aws-route53-backup.tf
+++ b/terraform/github/repositories/terraform-aws-route53-backup.tf
@@ -1,8 +1,8 @@
-module "teraform-aws-route53-backup" {
+module "terraform-aws-route53-backup" {
   source  = "ministryofjustice/repository/github"
   version = "0.0.8"
 
-  name            = "teraform-aws-route53-backup"
+  name            = "terraform-aws-route53-backup"
   description     = "A Terraform module for backup and restoration of Amazon Route 53 records."
   has_discussions = true
   topics          = ["operations-engineering", "terraform", "terraform-module"]


### PR DESCRIPTION
- Add definition for Route 53 backup terraform module repository 
- Repository is internal, at least during testing
- Also removed workflow dispatch trigger for terraform pipeline 