### PR TITLE
Retrieve and alert replay usage stats

### DIFF
--- a/bin/sentry_usage_alert.py
+++ b/bin/sentry_usage_alert.py
@@ -28,20 +28,28 @@ def main():
         SentryClient("https://sentry.io", sentry_token))
     slack_service = SlackService(slack_token)
 
-    error_usage_stats, transaction_usage_stats = sentry_service.get_quota_usage_for_period_in_days(
+    error_usage_stats, transaction_usage_stats, replay_usage_stats = sentry_service.get_quota_usage_for_period_in_days(
         period_in_days)
 
     logging.info(
         f"Error quota consumed over past {period_in_days} {'days' if period_in_days > 1 else 'day'} [ {error_usage_stats.total} / {error_usage_stats.max_usage} ]. Percentage consumed over period: [ {error_usage_stats.percentage_of_quota_used:.0%} ]")
     logging.info(
         f"Transaction quota consumed over past {period_in_days} {'days' if period_in_days > 1 else 'day'} [ {transaction_usage_stats.total} / {transaction_usage_stats.max_usage} ]. Percentage consumed over period: [ {transaction_usage_stats.percentage_of_quota_used:.0%} ]")
+    logging.info(
+        f"Replay quota consumed over past {period_in_days} {'days' if period_in_days > 1 else 'day'} [ {replay_usage_stats.total} / {replay_usage_stats.max_usage} ]. Percentage consumed over period: [ {replay_usage_stats.percentage_of_quota_used:.0%} ]")
 
     if error_usage_stats.percentage_of_quota_used > usage_threshold:
-        slack_service.send_error_usage_alert_to_operations_engineering(period_in_days, error_usage_stats,
-                                                                       usage_threshold)
+        slack_service.send_error_usage_alert_to_operations_engineering(
+            period_in_days, error_usage_stats, usage_threshold
+        )
     if transaction_usage_stats.percentage_of_quota_used > usage_threshold:
-        slack_service.send_transaction_usage_alert_to_operations_engineering(period_in_days, transaction_usage_stats,
-                                                                             usage_threshold)
+        slack_service.send_transaction_usage_alert_to_operations_engineering(
+            period_in_days, transaction_usage_stats, usage_threshold
+        )
+    if replay_usage_stats.percentage_of_quota_used > usage_threshold:
+        slack_service.send_usage_alert_to_operations_engineering(
+            period_in_days, replay_usage_stats, usage_threshold, "replay"
+        )
 
 
 if __name__ == "__main__":

--- a/services/sentry_service.py
+++ b/services/sentry_service.py
@@ -18,31 +18,40 @@ class SentryService:
     DAILY_ERROR_QUOTA = int(MONTHLY_ERROR_QUOTA / 31)
     MONTHLY_TRANSACTION_QUOTA = 30000000
     DAILY_TRANSACTION_QUOTA = int(MONTHLY_TRANSACTION_QUOTA / 31)
+    MONTHLY_REPLAY_QUOTA = 500
+    DAILY_REPLAY_QUOTA = int(MONTHLY_REPLAY_QUOTA / 31)
 
     def __init__(self, sentry_client: SentryClient):
         self.sentry_client = sentry_client
 
-    def __get_max_usage_for_period_in_days(self, period_in_days: int) -> tuple[int, int]:
+    def __get_max_usage_for_period_in_days(self, period_in_days: int) -> tuple[int, int, int]:
         max_error_usage_for_period = self.DAILY_ERROR_QUOTA * period_in_days
         max_transaction_usage_for_period = self.DAILY_TRANSACTION_QUOTA * period_in_days
+        max_replay_usage_for_period = self.DAILY_REPLAY_QUOTA * period_in_days
 
-        return max_error_usage_for_period, max_transaction_usage_for_period
+        return max_error_usage_for_period, max_transaction_usage_for_period, max_replay_usage_for_period
 
-    def get_quota_usage_for_period_in_days(self, period_in_days: int) -> tuple[UsageStats, UsageStats]:
+    def get_quota_usage_for_period_in_days(self, period_in_days: int) -> tuple[UsageStats, UsageStats, UsageStats]:
         error_total, error_start_time, error_end_time = self.sentry_client.get_usage_total_for_period_in_days(
             "error", period_in_days)
         transaction_total, transaction_start_time, transaction_end_time = self.sentry_client.get_usage_total_for_period_in_days(
             "transaction", period_in_days)
+        replay_total, replay_start_time, replay_end_time = self.sentry_client.get_usage_total_for_period_in_days(
+            "replay", period_in_days)
 
-        max_error_usage, max_transaction_usage = self.__get_max_usage_for_period_in_days(
+        max_error_usage, max_transaction_usage, max_replay_usage = self.__get_max_usage_for_period_in_days(
             period_in_days)
         percentage_of_error_quota_used = error_total / max_error_usage
         percentage_of_transaction_quota_used = transaction_total / max_transaction_usage
+        percentage_of_replay_quota_used = replay_total / max_replay_usage
 
         error_usage_stats = UsageStats(
             error_total, max_error_usage, percentage_of_error_quota_used, error_start_time, error_end_time)
         transaction_usage_stats = UsageStats(transaction_total, max_transaction_usage,
                                              percentage_of_transaction_quota_used, transaction_start_time,
                                              transaction_end_time)
+        replay_usage_stats = UsageStats(replay_total, max_replay_usage,
+                                             percentage_of_replay_quota_used, replay_start_time,
+                                             replay_end_time)
 
-        return error_usage_stats, transaction_usage_stats
+        return error_usage_stats, transaction_usage_stats, replay_usage_stats

--- a/services/slack_service.py
+++ b/services/slack_service.py
@@ -169,6 +169,119 @@ class SlackService:
                                                }
                                            ])
 
+    def send_transaction_usage_alert_to_operations_engineering(self, period_in_days: int, usage_stats: UsageStats,
+                                                               usage_threshold: float):
+        self.slack_client.chat_postMessage(channel=self.OPERATIONS_ENGINEERING_ALERTS_CHANNEL_ID,
+                                           mrkdown=True,
+                                           blocks=[
+                                               {
+                                                   "type": "section",
+                                                   "text": {
+                                                       "type": "mrkdwn",
+                                                       "text": dedent(f"""
+                                                           :warning: *Sentry Transactions Usage Alert :sentry::warning:*
+                                                           - Usage threshold: {usage_threshold:.0%}
+                                                           - Period: {period_in_days} {'days' if period_in_days > 1 else 'day'}
+                                                           - Max usage for period: {usage_stats.max_usage} Transactions
+                                                           - Transactions consumed over period: {usage_stats.total}
+                                                           - Percentage consumed: {usage_stats.percentage_of_quota_used:.0%}
+                                                       """).strip("\n")
+                                                   }
+                                               },
+                                               {
+                                                   "type": "divider"
+                                               },
+                                               {
+                                                   "type": "section",
+                                                   "text": {
+                                                       "type": "mrkdwn",
+                                                       "text": "Check Sentry for projects consuming excessive transactions :eyes:"
+                                                   },
+                                                   "accessory": {
+                                                       "type": "button",
+                                                       "text": {
+                                                           "type": "plain_text",
+                                                           "text": ":sentry: Transaction usage for period",
+                                                           "emoji": True
+                                                       },
+                                                       "url": f"https://ministryofjustice.sentry.io/stats/?dataCategory=transactions&end={quote(usage_stats.end_time.strftime(self.DATE_FORMAT))}&sort=-accepted&start={quote(usage_stats.start_time.strftime(self.DATE_FORMAT))}&utc=true"
+                                                   }
+                                               },
+                                               {
+                                                   "type": "section",
+                                                   "text": {
+                                                       "type": "mrkdwn",
+                                                       "text": "See Sentry usage alert runbook for help with this alert"
+                                                   },
+                                                   "accessory": {
+                                                       "type": "button",
+                                                       "text": {
+                                                           "type": "plain_text",
+                                                           "text": ":blue_book: Runbook",
+                                                           "emoji": True
+                                                       },
+                                                       "url": self.SENTRY_QUOTA_MANAGEMENT_GUIDANCE
+                                                   }
+                                               }
+                                           ])
+    def send_usage_alert_to_operations_engineering(self, period_in_days: int, usage_stats: UsageStats,
+                                                               usage_threshold: float, usage_type: str):
+        usage_type_lower = usage_type.lower()
+        usage_type_capitalised = usage_type.capitalize()
+        self.slack_client.chat_postMessage(channel=self.OPERATIONS_ENGINEERING_ALERTS_CHANNEL_ID,
+                                           mrkdown=True,
+                                           blocks=[
+                                               {
+                                                   "type": "section",
+                                                   "text": {
+                                                       "type": "mrkdwn",
+                                                       "text": dedent(f"""
+                                                           :warning: *Sentry {usage_type_capitalised} Usage Alert :sentry::warning:*
+                                                           - Usage threshold: {usage_threshold:.0%}
+                                                           - Period: {period_in_days} {'days' if period_in_days > 1 else 'day'}
+                                                           - Max usage for period: {usage_stats.max_usage} {usage_type_capitalised}s
+                                                           - {usage_type_capitalised}s consumed over period: {usage_stats.total}
+                                                           - Percentage consumed: {usage_stats.percentage_of_quota_used:.0%}
+                                                       """).strip("\n")
+                                                   }
+                                               },
+                                               {
+                                                   "type": "divider"
+                                               },
+                                               {
+                                                   "type": "section",
+                                                   "text": {
+                                                       "type": "mrkdwn",
+                                                       "text": f"Check Sentry for projects consuming excessive {usage_type_lower}s :eyes:"
+                                                   },
+                                                   "accessory": {
+                                                       "type": "button",
+                                                       "text": {
+                                                           "type": "plain_text",
+                                                           "text": f":sentry: {usage_type_capitalised} usage for period",
+                                                           "emoji": True
+                                                       },
+                                                       "url": f"https://ministryofjustice.sentry.io/stats/?dataCategory={usage_type_lower}s&end={quote(usage_stats.end_time.strftime(self.DATE_FORMAT))}&sort=-accepted&start={quote(usage_stats.start_time.strftime(self.DATE_FORMAT))}&utc=true"
+                                                   }
+                                               },
+                                               {
+                                                   "type": "section",
+                                                   "text": {
+                                                       "type": "mrkdwn",
+                                                       "text": "See Sentry usage alert runbook for help with this alert"
+                                                   },
+                                                   "accessory": {
+                                                       "type": "button",
+                                                       "text": {
+                                                           "type": "plain_text",
+                                                           "text": ":blue_book: Runbook",
+                                                           "emoji": True
+                                                       },
+                                                       "url": self.SENTRY_QUOTA_MANAGEMENT_GUIDANCE
+                                                   }
+                                               }
+                                           ])
+
     def send_unknown_user_alert_to_operations_engineering(self, users: list):
         self.slack_client.chat_postMessage(channel=self.OPERATIONS_ENGINEERING_ALERTS_CHANNEL_ID,
                                            mrkdown=True,


### PR DESCRIPTION
## 👀 Purpose

- To add an alert for Sentry Replay usage to our alerts channel

## ♻️ What's changed

- ✨Replay usage stats retrieval from Sentry API and transformation added to SentryService, and refactor from 2 to 3 outputs
- ♻️ Refactor SlackService `send_error_usage_alert_to_operations_engineering` and `send_transaction_usage_alert_to_operations_engineering` into `send_usage_alert_to_operations_engineering`
- ✨Update `bin/sentry_usage_alert.py` to deal with replay as well as error and transaction usage


## 📝 Notes

-