### PR TITLE
Restore route53 from backup

### DIFF
--- a/.github/workflows/job-restore-hosted-zones-from-backup.yml
+++ b/.github/workflows/job-restore-hosted-zones-from-backup.yml
@@ -1,12 +1,13 @@
 name: Restore DSD Hosted Zones From S3 Backup 
 
 on:
-  workflow_dispatch:
-    inputs:
-        hosted_zone_ids:
-            description: "A comma separated string of hosted zone ids to restore e.g. 'id1,id2,id3', or 'all' to restore all hosted zones"
-            required: true
-            type: string
+    pull_request:
+    workflow_dispatch:
+        inputs:
+            hosted_zone_ids:
+                description: "A comma separated string of hosted zone ids to restore e.g. 'id1,id2,id3', or 'all' to restore all hosted zones"
+                required: true
+                type: string
 
 jobs:
   restore-from-backup:
@@ -26,7 +27,7 @@ jobs:
           aws-region: eu-west-2
 
       - run: python3 -m pip install -r requirements.txt
-      - run: python3 -m bin.restore_route53_from_backup ${{inputs.hosted_zone_ids}}
+    #   - run: python3 -m bin.restore_route53_from_backup ${{inputs.hosted_zone_ids}}
 
     #   - name: Report failure to Slack
     #     if: always()

--- a/.github/workflows/job-restore-hosted-zones-from-backup.yml
+++ b/.github/workflows/job-restore-hosted-zones-from-backup.yml
@@ -1,7 +1,6 @@
 name: Restore DSD Hosted Zones From S3 Backup 
 
 on:
-    pull_request:
     workflow_dispatch:
         inputs:
             hosted_zone_ids:

--- a/.github/workflows/job-restore-hosted-zones-from-backup.yml
+++ b/.github/workflows/job-restore-hosted-zones-from-backup.yml
@@ -22,18 +22,26 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: ${{ secrets.R53_BACKUP_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - run: python3 -m bin.import_route53_backup 
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
           role-to-assume: ${{ secrets.AWS_DSD_R53_RESTORE_FROM_BACKUP_ROLE_ARN }}
           aws-region: eu-west-2
 
       - run: python3 -m pip install -r requirements.txt
-    #   - run: python3 -m bin.restore_route53_from_backup ${{inputs.hosted_zone_ids}}
+      - run: python3 -m bin.restore_route53_from_backup ${{inputs.hosted_zone_ids}}
 
-    #   - name: Report failure to Slack
-    #     if: always()
-    #     uses: ravsamhq/notify-slack-action@v2
-    #     with:
-    #       status: ${{ job.status }}
-    #       notify_when: "failure"
-    #       notification_title: "Failed to backup Route 53"
-    #     env:
-    #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to backup Route 53"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-restore-hosted-zones-from-backup.yml
+++ b/.github/workflows/job-restore-hosted-zones-from-backup.yml
@@ -1,0 +1,39 @@
+name: Restore DSD Hosted Zones From S3 Backup 
+
+on:
+  workflow_dispatch:
+    inputs:
+        hosted_zone_ids:
+            description: "A comma separated string of hosted zone ids to restore e.g. 'id1,id2,id3', or 'all' to restore all hosted zones"
+            required: true
+            type: string
+
+jobs:
+  restore-from-backup:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DSD_R53_RESTORE_FROM_BACKUP_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - run: python3 -m pip install -r requirements.txt
+      - run: python3 -m bin.restore_route53_from_backup ${{inputs.hosted_zone_ids}}
+
+    #   - name: Report failure to Slack
+    #     if: always()
+    #     uses: ravsamhq/notify-slack-action@v2
+    #     with:
+    #       status: ${{ job.status }}
+    #       notify_when: "failure"
+    #       notification_title: "Failed to backup Route 53"
+    #     env:
+    #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-route-53-backup.yml
+++ b/.github/workflows/job-route-53-backup.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_DSD_R53_EXPORT_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_R53_EXPORT_ROLE_DEV_ARN }}
           aws-region: eu-west-2
 
       - run: python3 -m pip install -r requirements.txt

--- a/.github/workflows/job-route-53-backup.yml
+++ b/.github/workflows/job-route-53-backup.yml
@@ -31,7 +31,9 @@ jobs:
           role-to-assume: ${{ secrets.R53_BACKUP_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - run: python3 -m bin.send_route_53_backup_to_s3
+      - run: python3 -m bin.send_route_53_backup_to_s3 
+
+      - run: aws s3api get-object --bucket cloud-platform-50ad54b3b789d9fba7b301cce9d35f39 --key hosted_zones.json test.json && cat test.json 
 
       - name: Report failure to Slack
         if: always()

--- a/bin/import_route53_backup.py
+++ b/bin/import_route53_backup.py
@@ -1,0 +1,11 @@
+from services.s3_service import S3Service
+
+def import_route53_backup(s3_service: S3Service):
+    s3_service._download_file('hosted_zones.json', 'hosted_zones.json')
+
+def main():
+    s3_service = S3Service("cloud-platform-50ad54b3b789d9fba7b301cce9d35f39", "")
+    import_route53_backup(s3_service)
+
+if __name__ == "__main__":
+    main()

--- a/bin/restore_route53_from_backup.py
+++ b/bin/restore_route53_from_backup.py
@@ -5,7 +5,6 @@ import sys
 import json
 
 def restore_route53_from_backup(s3_service: S3Service, r53_service: Route53Service, hosted_zones):
-    s3_service._download_file('hosted_zones.json', 'hosted_zones.json')
 
     f = open('hosted_zones.json')
 

--- a/bin/restore_route53_from_backup.py
+++ b/bin/restore_route53_from_backup.py
@@ -1,0 +1,28 @@
+from services.s3_service import S3Service
+from services.route_53_service import Route53Service
+import os 
+import sys
+import json
+
+def restore_route53_from_backup(s3_service: S3Service, r53_service: Route53Service, hosted_zones):
+    s3_service._download_file('hosted_zones.json', 'hosted_zones.json')
+
+    f = open('hosted_zones.json')
+
+    json_data = json.load(f)
+
+    f.close()
+
+    r53_service.bulk_restore_hosted_zones(json_data, hosted_zones)
+
+    os.remove("hosted_zones.json")
+
+
+def main():
+    s3_service = S3Service("cloud-platform-50ad54b3b789d9fba7b301cce9d35f39", "")
+    r53_service = Route53Service()
+    hosted_zones = sys.argv[0].split(',')
+    restore_route53_from_backup(s3_service, r53_service, hosted_zones)
+
+if __name__ == "__main__":
+    main()

--- a/services/route_53_service.py
+++ b/services/route_53_service.py
@@ -1,6 +1,5 @@
 import boto3
 import json
-from datetime import datetime
 
 
 class Route53Service:
@@ -11,9 +10,11 @@ class Route53Service:
 
         response = self.client.list_hosted_zones()
 
-        hosted_zone_ids = [zone['Id'] for zone in response['HostedZones']]
+        hosted_zone_data = []
+        for zone in response['HostedZones']:
+            hosted_zone_data.append({'id': zone['Id'], 'name': zone['Name']})
 
-        return hosted_zone_ids
+        return hosted_zone_data 
     
     def export_route53_records(self, zone_id: str):
 
@@ -42,12 +43,98 @@ class Route53Service:
     
     def bulk_export_route53_records(self):
 
-        hosted_zone_ids = self.get_route53_hosted_zones()
+        hosted_zone_data = self.get_route53_hosted_zones()
 
         exported_records = {}
 
-        for zone_id in hosted_zone_ids:
-            records = self.export_route53_records(zone_id)
-            exported_records[zone_id] = records
+        for zone in hosted_zone_data:
+            records = self.export_route53_records(zone['id'])
+            exported_records[zone['id']] = {'name': zone['name'], 'records': records}
 
         return json.dumps(exported_records, indent=4)
+    
+    def check_if_hosted_zone_exists(self, hosted_zone_id):
+        try:
+            self.client.get_hosted_zone(Id=hosted_zone_id)
+            print(f"Hosted zone '{hosted_zone_id}' already exists.")
+            return True
+        except self.client.exceptions.NoSuchHostedZone:
+            print(f"Hosted zone '{hosted_zone_id}' doesn't exist.")
+            return False
+    
+    def restore_hosted_zone(self, hosted_zone_id, hosted_zone_name):
+        if not self.check_if_hosted_zone_exists(hosted_zone_id):
+            caller_reference = str(hash(hosted_zone_id))
+            zone = self.client.create_hosted_zone(Name=hosted_zone_name, CallerReference=caller_reference)
+            print(f"Created hosted zone '{hosted_zone_name}'.")
+            return zone['HostedZone']['Id']
+        else:
+            print(f"A hosted zone with id '{hosted_zone_id}' already exists")
+            return False
+        
+    def check_if_record_exists(self, hosted_zone_id, record_name, record_type):
+        records = self.client.list_resource_record_sets(HostedZoneId=hosted_zone_id)['ResourceRecordSets']
+        for record in records:
+            if record["Name"] == record_name and record["Type"] == record_type:
+                print(f"Resource record '{record_name}' of type '{record_type}' already exists.")
+                return True
+        return False
+    
+    def create_change(self, record):
+        change = {
+            'Action': 'CREATE',
+            'ResourceRecordSet': {
+                'Name': record['Name'],
+                'Type': record['Type'],
+                'TTL': record['TTL'],
+            }
+        }
+
+        if 'ResourceRecords' in record:
+            change['ResourceRecordSet']['ResourceRecords'] = [{'Value': value} for value in record['ResourceRecords']]
+        elif 'AliasTarget' in record:
+            change['ResourceRecordSet']['AliasTarget'] = record['AliasTarget']
+
+        return change
+
+    def create_change_batch(self, hosted_zone_id, records):
+        changes = []
+        for record in records:
+            if not self.check_if_record_exists(hosted_zone_id, record['Name'], record['Type']):
+                change = self.create_change(record)
+                changes.append(change)
+        return changes
+    
+    def restore_hosted_zone_records(self, hosted_zone_id, records):
+        if not self.check_if_hosted_zone_exists(hosted_zone_id):
+            return False
+        
+        changes = self.create_change_batch(hosted_zone_id, records)
+        response = self.client.change_resource_record_sets(
+            HostedZoneId=hosted_zone_id,
+            ChangeBatch={
+                'Changes': changes
+            }
+        )
+        print("Hosted zone records restored successfully.")
+        print("Change info:", response)
+
+    def bulk_restore_hosted_zones(self, json_backup, hosted_zones_to_restore):
+
+        backup_data = json.loads(json_backup)
+
+        new_zone_ids = []
+
+        if hosted_zones_to_restore == 'all':
+            for hz_id in backup_data.keys():
+                new_zone_id = self.restore_hosted_zone(hz_id, backup_data[hz_id]['name'])
+                self.restore_hosted_zone_records(new_zone_id, backup_data[hz_id]['records'])
+                new_zone_ids.append(new_zone_id)
+        else:
+            for hz_id in hosted_zones_to_restore:
+                if hz_id in backup_data.keys():
+                    new_zone_id = self.restore_hosted_zone(hz_id, backup_data[hz_id]['name'])
+                    self.restore_hosted_zone_records(new_zone_id, backup_data[hz_id]['records'])
+                    new_zone_ids.append(new_zone_id)
+        
+        return new_zone_ids

--- a/services/route_53_service.py
+++ b/services/route_53_service.py
@@ -121,11 +121,11 @@ class Route53Service:
 
     def bulk_restore_hosted_zones(self, json_backup, hosted_zones_to_restore):
 
-        backup_data = json.loads(json_backup)
+        backup_data = json_backup
 
         new_zone_ids = []
 
-        if hosted_zones_to_restore == 'all':
+        if hosted_zones_to_restore == ['all']:
             for hz_id in backup_data.keys():
                 new_zone_id = self.restore_hosted_zone(hz_id, backup_data[hz_id]['name'])
                 self.restore_hosted_zone_records(new_zone_id, backup_data[hz_id]['records'])

--- a/test/test_bin/test_restore_route53_from_backup.py
+++ b/test/test_bin/test_restore_route53_from_backup.py
@@ -1,0 +1,40 @@
+import unittest
+import sys
+import json
+from unittest.mock import patch
+from bin.restore_route53_from_backup import main
+from services.s3_service import S3Service
+from services.route_53_service import Route53Service
+
+class TestRestoreRoute53FromBackup(unittest.TestCase):
+
+    @patch.object(Route53Service, "bulk_restore_hosted_zones")
+    @patch.object(S3Service, "_download_file")
+    def test_main_all(self, mock_download_file, mock_bulk_restore_hosted_zones):
+        mock_json_data = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
+
+        with open('hosted_zones.json', "w") as json_file:
+            json_file.write(json.dumps(mock_json_data))
+
+        hz_ids = ['all']
+
+        with patch.object(sys, 'argv', ['all']):
+            main()
+            mock_bulk_restore_hosted_zones.assert_called_once_with(mock_json_data, hz_ids)
+    
+    @patch.object(Route53Service, "bulk_restore_hosted_zones")
+    @patch.object(S3Service, "_download_file")
+    def test_main_specified_hosted_zones(self, mock_download_file, mock_bulk_restore_hosted_zones):
+        mock_json_data = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
+
+        with open('hosted_zones.json', "w") as json_file:
+            json_file.write(json.dumps(mock_json_data))
+
+        hz_ids = ['hz1', 'hz2', 'hz3']
+
+        with patch.object(sys, 'argv', ['hz1,hz2,hz3']):
+            main()
+            mock_bulk_restore_hosted_zones.assert_called_once_with(mock_json_data, hz_ids)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_bin/test_restore_route53_from_backup.py
+++ b/test/test_bin/test_restore_route53_from_backup.py
@@ -9,8 +9,7 @@ from services.route_53_service import Route53Service
 class TestRestoreRoute53FromBackup(unittest.TestCase):
 
     @patch.object(Route53Service, "bulk_restore_hosted_zones")
-    @patch.object(S3Service, "_download_file")
-    def test_main_all(self, mock_download_file, mock_bulk_restore_hosted_zones):
+    def test_main_all(self, mock_bulk_restore_hosted_zones):
         mock_json_data = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
 
         with open('hosted_zones.json', "w") as json_file:

--- a/test/test_services/test_route_53_service.py
+++ b/test/test_services/test_route_53_service.py
@@ -176,8 +176,8 @@ class TestRoute53Service(unittest.TestCase):
 
     @mock_aws
     def test_bulk_restore_hosted_zones_all(self):
-        json_backup = json.dumps({'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}})
-        hosted_zones_to_restore = "all"
+        json_backup = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
+        hosted_zones_to_restore = ["all"]
         new_zone_ids = self.route_53_service.bulk_restore_hosted_zones(json_backup, hosted_zones_to_restore)
         hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][0]
         hz_records = self.route_53_service.client.list_resource_record_sets(HostedZoneId=new_zone_ids[0])['ResourceRecordSets']
@@ -187,7 +187,7 @@ class TestRoute53Service(unittest.TestCase):
 
     @mock_aws
     def test_bulk_restore_hosted_zones_all(self):
-        json_backup = json.dumps({'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}})
+        json_backup = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
         hosted_zones_to_restore = ['/hostedzone/Z31RX3GZS94JZS']
         new_zone_ids = self.route_53_service.bulk_restore_hosted_zones(json_backup, hosted_zones_to_restore)
         hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][0]

--- a/test/test_services/test_route_53_service.py
+++ b/test/test_services/test_route_53_service.py
@@ -176,18 +176,36 @@ class TestRoute53Service(unittest.TestCase):
 
     @mock_aws
     def test_bulk_restore_hosted_zones_all(self):
-        json_backup = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
+        json_backup = {'/hostedzone/Z31RX3GZS94JZS': 
+                       {'name': 'testdns.aws.com.', 
+                        'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]
+                        },
+                        '/hostedzone/adasdasdas': 
+                        {'name': 'testdns2.aws.com.', 
+                        'records': [{'Name': 'testdns2.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns2.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns2.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]
+                        }
+                    }
+        json_backup_keys = json_backup.keys()
         hosted_zones_to_restore = ["all"]
         new_zone_ids = self.route_53_service.bulk_restore_hosted_zones(json_backup, hosted_zones_to_restore)
-        hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][0]
-        hz_records = self.route_53_service.client.list_resource_record_sets(HostedZoneId=new_zone_ids[0])['ResourceRecordSets']
-        assert hz_data['Id'] == new_zone_ids[0]
-        assert hz_data['Name'] == 'testdns.aws.com.'
-        assert hz_records == [{'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}, {'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': [{'Value': 'ns-2048.awsdns-64.com'}, {'Value': 'ns-2049.awsdns-65.net'}, {'Value': 'ns-2050.awsdns-66.org'}, {'Value': 'ns-2051.awsdns-67.co.uk'}]}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': [{'Value': "{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"}]}]
+        for i in len(json_backup_keys):
+            hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][i]
+            hz_records = self.route_53_service.client.list_resource_record_sets(HostedZoneId=new_zone_ids[i])['ResourceRecordSets']
+            assert hz_data['Id'] == new_zone_ids[i]
+            assert hz_data['Name'] == json_backup[json_backup_keys[i]]['name']
+            assert hz_records == json_backup[json_backup_keys[i]]['records']
 
     @mock_aws
     def test_bulk_restore_hosted_zones_all(self):
-        json_backup = {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}}
+        json_backup = {'/hostedzone/Z31RX3GZS94JZS': 
+                       {'name': 'testdns.aws.com.', 
+                        'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]
+                        },
+                        '/hostedzone/adasdasdas': 
+                        {'name': 'testdns2.aws.com.', 
+                        'records': [{'Name': 'testdns2.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns2.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns2.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]
+                        }
+                    }
         hosted_zones_to_restore = ['/hostedzone/Z31RX3GZS94JZS']
         new_zone_ids = self.route_53_service.bulk_restore_hosted_zones(json_backup, hosted_zones_to_restore)
         hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][0]

--- a/test/test_services/test_route_53_service.py
+++ b/test/test_services/test_route_53_service.py
@@ -18,7 +18,8 @@ class TestRoute53Service(unittest.TestCase):
 
         res = self.route_53_service.get_route53_hosted_zones()
 
-        assert res[0] == zone['HostedZone']['Id']
+        assert res[0]['id'] == zone['HostedZone']['Id']
+        assert res[0]['name'] == zone['HostedZone']['Name']
 
     @mock_aws
     def test_export_route53_records(self):
@@ -73,7 +74,7 @@ class TestRoute53Service(unittest.TestCase):
     @patch.object(Route53Service, "export_route53_records")
     def test_bulk_export_route53_records(self, mock_records, mock_zone_id):
 
-        mock_zone_id.return_value = ["/hostedzone/Z31RX3GZS94JZS"]
+        mock_zone_id.return_value = [{"id": "/hostedzone/Z31RX3GZS94JZS", "name": "testdns.aws.com."}]
         mock_records.return_value = [
             {'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, 
             {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}
@@ -81,7 +82,121 @@ class TestRoute53Service(unittest.TestCase):
 
         res = self.route_53_service.bulk_export_route53_records()
 
-        assert json.loads(res) == {'/hostedzone/Z31RX3GZS94JZS': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}]}
+        assert json.loads(res) == {'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}]}}
+
+    @mock_aws
+    def test_check_if_hosted_zone_exists_if_true(self):
+        zone = self.route_53_service.client.create_hosted_zone(Name="testdns.aws.com.", CallerReference=str(hash("foo")))
+        res = self.route_53_service.check_if_hosted_zone_exists(zone['HostedZone']['Id'])
+        assert res == True
+
+    @mock_aws
+    def test_check_if_hosted_zone_exists_if_false(self):
+        res = self.route_53_service.check_if_hosted_zone_exists('/hostedzone/Z31RX3GZS94JZS')
+        assert res == False
+        
+    @patch.object(Route53Service, "check_if_hosted_zone_exists")
+    @mock_aws
+    def test_restore_hosted_zone_if_doesnt_exist(self, mock_response):
+        mock_response.return_value = False
+        res = self.route_53_service.restore_hosted_zone('/hostedzone/Z31RX3GZS94JZS', 'testdns.aws.com.')
+        hosted_zone_data = self.route_53_service.client.list_hosted_zones()['HostedZones']
+        assert hosted_zone_data[0]['Name'] == 'testdns.aws.com.'
+        assert res == hosted_zone_data[0]['Id']
+
+    @patch.object(Route53Service, "check_if_hosted_zone_exists")
+    def test_restore_hosted_zone_if_exists(self, mock_response):
+        mock_response.return_value = True
+        res = self.route_53_service.restore_hosted_zone('/hostedzone/Z31RX3GZS94JZS', 'testdns.aws.com.')          
+        assert res == False                
+
+    @mock_aws
+    def test_check_if_record_exists_if_false(self):
+        zone = self.route_53_service.client.create_hosted_zone(Name="testdns.aws.com.", CallerReference=str(hash("foo")))
+        res = self.route_53_service.check_if_record_exists(zone['HostedZone']['Id'], "testdns.aws.com.", "MX")
+        assert res == False
+
+    @mock_aws
+    def test_check_if_record_exists_if_true(self):
+        zone = self.route_53_service.client.create_hosted_zone(Name="testdns.aws.com.", CallerReference=str(hash("foo")))
+        self.route_53_service.client.change_resource_record_sets(
+            HostedZoneId=zone['HostedZone']['Id'],
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "CREATE",
+                        "ResourceRecordSet": {
+                            "Name": "testdns.aws.com.",
+                            "Type": "MX",
+                            "TTL": 1800,
+                            "ResourceRecords": [
+                                {"Value": "10 inbound-smtp.eu-west-1.amazonaws.com"}
+                            ]
+                        },
+                    }
+                ]
+            },
+        )
+
+        res = self.route_53_service.check_if_record_exists(zone['HostedZone']['Id'], "testdns.aws.com.", "MX")
+        assert res == True
+
+    def test_create_change(self):
+        record = {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}
+        res = self.route_53_service.create_change(record)
+        assert res == {'Action': 'CREATE', 'ResourceRecordSet': {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}}
+
+    @patch.object(Route53Service, "create_change")
+    @patch.object(Route53Service, "check_if_record_exists")
+    def test_create_change_batch_if_new_changes(self, mock_check_if_record_exists, mock_change):
+        mock_check_if_record_exists.return_value = False
+        mock_change.return_value = {'Action': 'CREATE', 'ResourceRecordSet': {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}}
+        res = self.route_53_service.create_change_batch('/hostedzone/Z31RX3GZS94JZS', [{'Name': 'test', 'Type': 'test'}])
+        assert res == [{'Action': 'CREATE', 'ResourceRecordSet': {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}}]
+
+    @patch.object(Route53Service, "check_if_record_exists")
+    def test_create_change_batch_if_record_exists(self, mock_check_if_record_exists):
+        mock_check_if_record_exists.return_value = True
+        res = self.route_53_service.create_change_batch(mock_check_if_record_exists, mock_check_if_record_exists)
+        assert res == []
+
+    @mock_aws
+    @patch.object(Route53Service, "create_change_batch")
+    def test_restore_hosted_zone_records_if_zone_exists(self, mock_change_batch):
+        mock_change_batch.return_value = [{'Action': 'CREATE', 'ResourceRecordSet': {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}}]
+        zone = self.route_53_service.client.create_hosted_zone(Name="testdns.aws.com.", CallerReference=str(hash("foo")))
+        self.route_53_service.restore_hosted_zone_records(zone['HostedZone']['Id'], mock_change_batch)
+        res = self.route_53_service.client.list_resource_record_sets(HostedZoneId=zone['HostedZone']['Id'])['ResourceRecordSets'][0]
+        assert res == {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}
+
+    @mock_aws
+    def test_restore_hosted_zone_records_if_zone_doesnt_exists(self):
+        res = self.route_53_service.restore_hosted_zone_records('/hostedzone/Z31RX3GZS94JZS', [])
+        assert res == False
+
+    @mock_aws
+    def test_bulk_restore_hosted_zones_all(self):
+        json_backup = json.dumps({'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}})
+        hosted_zones_to_restore = "all"
+        new_zone_ids = self.route_53_service.bulk_restore_hosted_zones(json_backup, hosted_zones_to_restore)
+        hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][0]
+        hz_records = self.route_53_service.client.list_resource_record_sets(HostedZoneId=new_zone_ids[0])['ResourceRecordSets']
+        assert hz_data['Id'] == new_zone_ids[0]
+        assert hz_data['Name'] == 'testdns.aws.com.'
+        assert hz_records == [{'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}, {'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': [{'Value': 'ns-2048.awsdns-64.com'}, {'Value': 'ns-2049.awsdns-65.net'}, {'Value': 'ns-2050.awsdns-66.org'}, {'Value': 'ns-2051.awsdns-67.co.uk'}]}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': [{'Value': "{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"}]}]
+
+    @mock_aws
+    def test_bulk_restore_hosted_zones_all(self):
+        json_backup = json.dumps({'/hostedzone/Z31RX3GZS94JZS': {'name': 'testdns.aws.com.', 'records': [{'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': ['ns-2048.awsdns-64.com', 'ns-2049.awsdns-65.net', 'ns-2050.awsdns-66.org', 'ns-2051.awsdns-67.co.uk']}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': ["{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"]}, {'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': ['10 inbound-smtp.eu-west-1.amazonaws.com']}]}})
+        hosted_zones_to_restore = ['/hostedzone/Z31RX3GZS94JZS']
+        new_zone_ids = self.route_53_service.bulk_restore_hosted_zones(json_backup, hosted_zones_to_restore)
+        hz_data = self.route_53_service.client.list_hosted_zones()['HostedZones'][0]
+        hz_records = self.route_53_service.client.list_resource_record_sets(HostedZoneId=new_zone_ids[0])['ResourceRecordSets']
+        assert hz_data['Id'] == new_zone_ids[0]
+        assert hz_data['Name'] == 'testdns.aws.com.'
+        assert hz_records == [{'Name': 'testdns.aws.com.', 'Type': 'MX', 'TTL': 1800, 'ResourceRecords': [{'Value': '10 inbound-smtp.eu-west-1.amazonaws.com'}]}, {'Name': 'testdns.aws.com.', 'Type': 'NS', 'TTL': 172800, 'ResourceRecords': [{'Value': 'ns-2048.awsdns-64.com'}, {'Value': 'ns-2049.awsdns-65.net'}, {'Value': 'ns-2050.awsdns-66.org'}, {'Value': 'ns-2051.awsdns-67.co.uk'}]}, {'Name': 'testdns.aws.com.', 'Type': 'SOA', 'TTL': 900, 'ResourceRecords': [{'Value': "{'Value': 'ns-2048.awsdns-64.com. hostmaster.example.com. 1 7200 900 1209600 86400'}"}]}]
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Manually triggered workflow which takes inputs (hosted zone ids separated by ',' e.g. 'id1,id2,id3' or 'all'), pulls backed up JSON data from S3 bucket and restores specified R53 hosted zones.
- Structure of JSON backup amended to {zone_id: {zone_name: value, records: [...]}}, to store name of each hosted zone, also adds debug step to backup workflow.
- New jobs added:
  - import_route53_backup - imports JSON backup data from CP S3 bucket
  - restore_route53_from_backup - bulk_restore_hosted_zones function with system arguments and json data 
- New functions added to R53 service:
  - check_if_hosted_zone_exists - checks if hosted zone already exists
  - restore_hosted_zone - creates a new hosted zone if it doesn't already exist and returns new hosted zone id
  - check_if_record_exists - check if record with same name and type exists in hosted zone
  - create_change - create record change request if 
  - create_change_batch - create record change set for all new records
  - restore_hosted_zone_records - adds resource record sets to hosted zone 
  - bulk_restore_hosted_zones - restores specified hosted zones and all associated records (will only restore records that are missing compared to backup, therefore can be used to restore a single record of a hosted zone)
- Unit tests added for new jobs and services. 

***Github Actions secret AWS_R53_EXPORT_ROLE_DEV_ARN is not yet set to role ARN - First access must be granted to a test account where R53 restoration operations may be tested before this secret is populated.***