### PR TITLE
Github Actions Quota Usage

### DIFF
--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -21,10 +21,7 @@ jobs:
           python-version: "3.11"
       - run: python3 -m pip install -r requirements.txt
 
-      - run: |
-          gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD -f name='GHA_MINUTES_QUOTA_THRESHOLD' -f value='80'   
-
-      # - run: python3 -m bin.alert_on_low_github_actions_quota
+      - run: python3 -m bin.alert_on_low_github_actions_quota
 
     #   - name: Report failure to Slack
     #     if: always()

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -22,7 +22,7 @@ jobs:
       - run: python3 -m pip install -r requirements.txt
 
       - run: |
-        gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD -f name='GHA_MINUTES_QUOTA_THRESHOLD' -f value='80'   
+          gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD -f name='GHA_MINUTES_QUOTA_THRESHOLD' -f value='80'   
 
       # - run: python3 -m bin.alert_on_low_github_actions_quota
 

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -21,7 +21,10 @@ jobs:
           python-version: "3.11"
       - run: python3 -m pip install -r requirements.txt
 
-      - run: python3 -m bin.alert_on_low_github_actions_quota
+      - run: |
+        gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD -f name='GHA_MINUTES_QUOTA_THRESHOLD' -f value='80'   
+
+      # - run: python3 -m bin.alert_on_low_github_actions_quota
 
     #   - name: Report failure to Slack
     #     if: always()

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
+  pull_request:
 
 env:
   ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -22,12 +22,12 @@ jobs:
 
       - run: python3 -m bin.alert_on_low_github_actions_quota
 
-      - name: Report failure to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "Failed to check for low GitHub seats"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Report failure to Slack
+      #   if: always()
+      #   uses: ravsamhq/notify-slack-action@v2
+      #   with:
+      #     status: ${{ job.status }}
+      #     notify_when: "failure"
+      #     notification_title: "Failed to check for low GitHub actions minutes"
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
-  pull_request:
 
 env:
   ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
@@ -22,12 +21,12 @@ jobs:
 
       - run: python3 -m bin.alert_on_low_github_actions_quota
 
-      # - name: Report failure to Slack
-      #   if: always()
-      #   uses: ravsamhq/notify-slack-action@v2
-      #   with:
-      #     status: ${{ job.status }}
-      #     notify_when: "failure"
-      #     notification_title: "Failed to check for low GitHub seats"
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to check for low GitHub seats"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
-  pull_request:
 
 env:
   ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
-  pull_request:
 
 env:
   ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
@@ -22,12 +21,12 @@ jobs:
 
       - run: python3 -m bin.alert_on_low_github_actions_quota
 
-    #   - name: Report failure to Slack
-    #     if: always()
-    #     uses: ravsamhq/notify-slack-action@v2
-    #     with:
-    #       status: ${{ job.status }}
-    #       notify_when: "failure"
-    #       notification_title: "Failed to check for low GitHub seats"
-    #     env:
-    #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to check for low GitHub seats"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -1,4 +1,4 @@
-name: Alarm if remaining GIthub Actions quota is low
+name: Alarm if remaining GitHub Actions quota is low
 
 on:
   schedule:

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -21,12 +21,12 @@ jobs:
 
       - run: python3 -m bin.alert_on_low_github_actions_quota
 
-      # - name: Report failure to Slack
-      #   if: always()
-      #   uses: ravsamhq/notify-slack-action@v2
-      #   with:
-      #     status: ${{ job.status }}
-      #     notify_when: "failure"
-      #     notification_title: "Failed to check for low GitHub actions minutes"
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed to check for low GitHub actions minutes"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
+  pull_request:
 
 env:
   ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
@@ -21,12 +22,12 @@ jobs:
 
       - run: python3 -m bin.alert_on_low_github_actions_quota
 
-      - name: Report failure to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v2
-        with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-          notification_title: "Failed to check for low GitHub seats"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Report failure to Slack
+      #   if: always()
+      #   uses: ravsamhq/notify-slack-action@v2
+      #   with:
+      #     status: ${{ job.status }}
+      #     notify_when: "failure"
+      #     notification_title: "Failed to check for low GitHub seats"
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -9,7 +9,6 @@ on:
 env:
   ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
   GH_TOKEN: ${{ secrets.OPS_ENG_ENTERPRISE_BILLING_PAT_TOKEN }}
-  GHA_MINUTES_QUOTA_THRESHOLD: ${{ vars.GHA_MINUTES_QUOTA_THRESHOLD }}
 
 jobs:
   low-quota-threshold:

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -7,9 +7,9 @@ import datetime
 import time
 
 def reset_alerting_threshold_if_first_day_of_month(github_service):
-    base_alerting_threshold = 7
+    base_alerting_threshold = 70
 
-    if datetime.date.today().day == 14:
+    if datetime.date.today().day == 1:
         github_service.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
 def calculate_percentage_used(total_minutes_used):
@@ -51,7 +51,7 @@ def alert_on_low_quota():
     if percentage_used >= threshold:
         slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
         github_service.modify_gha_minutes_quota_threshold(threshold + 10)
-        
+
 
 if __name__ == "__main__":
     alert_on_low_quota()

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -24,10 +24,12 @@ def calculate_total_minutes_used(organisations, github_service):
     
     for org in organisations:
         billing_data = github_service.get_gha_minutes_used_for_organisation(org.login)
-        processed_data = json.loads(billing_data)
-        minutes_used = processed_data["total_minutes_used"]
+        # processed_data = json.loads(billing_data)
+        minutes_used = billing_data["total_minutes_used"]
         total += minutes_used
 
+    print(total)
+    
     return total
 
 def alert_on_low_quota():

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -51,7 +51,6 @@ def alert_on_low_quota():
         slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
         github_service.modify_gha_minutes_quota_threshold(threshold + 10)
 
-
 if __name__ == "__main__":
     alert_on_low_quota()
 

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -51,6 +51,7 @@ def alert_on_low_quota():
     if percentage_used >= threshold:
         slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
         github_service.modify_gha_minutes_quota_threshold(threshold + 10)
+        
 
 if __name__ == "__main__":
     alert_on_low_quota()

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -2,13 +2,6 @@ from services.github_service import GithubService
 from config.constants import ENTERPRISE, MINISTRY_OF_JUSTICE, SLACK_CHANNEL
 import os
 from services.slack_service import SlackService
-import datetime
-
-def reset_alerting_threshold_if_first_day_of_month(github_service):
-    base_alerting_threshold = 70
-
-    if datetime.date.today().day == 1:
-        github_service.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
 def calculate_percentage_used(total_minutes_used):
     total_available = 50000
@@ -41,7 +34,7 @@ def alert_on_low_quota():
 
     percentage_used = calculate_percentage_used(total_minutes_used)
 
-    reset_alerting_threshold_if_first_day_of_month(github_service)
+    github_service.reset_alerting_threshold_if_first_day_of_month()
 
     threshold = github_service.get_gha_minutes_quota_threshold()
 

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -22,7 +22,7 @@ def alert_on_low_quota():
 
     check_result = github_service.check_if_quota_is_low()
 
-    if check_result:
+    if check_result != False:
         slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(check_result['percentage_used']), SLACK_CHANNEL)
         github_service.modify_gha_minutes_quota_threshold(check_result['threshold'] + 10)
 

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -8,7 +8,7 @@ import datetime
 def reset_alerting_threshold_if_first_day_of_month(github_service):
     base_alerting_threshold = 70
 
-    if datetime.date.today().day == 1:
+    if datetime.date.today().day == 13:
         github_service.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
 def calculate_percentage_used(total_minutes_used):

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -9,7 +9,7 @@ import time
 def reset_alerting_threshold_if_first_day_of_month(github_service):
     base_alerting_threshold = 70
 
-    if datetime.date.today().day == 13:
+    if datetime.date.today().day == 1:
         github_service.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
 def calculate_percentage_used(total_minutes_used):
@@ -31,8 +31,7 @@ def calculate_total_minutes_used(organisations, github_service):
 
     return total
 
-
-def alert_on_low_github_actions_quota():
+def alert_on_low_quota():
     github_token = os.environ.get("GH_TOKEN")
     slack_token = os.environ.get("ADMIN_SLACK_TOKEN")
 
@@ -49,13 +48,11 @@ def alert_on_low_github_actions_quota():
 
     threshold = github_service.get_gha_minutes_quota_threshold()
 
-    print(threshold)
-
-    # if percentage_used >= threshold:
-        # slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
-        # github_service.modify_gha_minutes_quota_threshold(threshold + 10)
+    if percentage_used >= threshold:
+        slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
+        github_service.modify_gha_minutes_quota_threshold(threshold + 10)
 
 if __name__ == "__main__":
-    alert_on_low_github_actions_quota()
+    alert_on_low_quota()
 
 

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -4,6 +4,7 @@ import os
 import json
 from services.slack_service import SlackService
 import datetime
+import time
 
 def reset_alerting_threshold_if_first_day_of_month(github_service):
     base_alerting_threshold = 70
@@ -46,11 +47,13 @@ def alert_on_low_github_actions_quota():
 
     reset_alerting_threshold_if_first_day_of_month(github_service)
 
-    threshold = int(os.environ.get("GHA_MINUTES_QUOTA_THRESHOLD"))
+    threshold = github_service.get_gha_minutes_quota_threshold()
 
-    if percentage_used >= threshold:
-        slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
-        github_service.modify_gha_minutes_quota_threshold(threshold + 10)
+    print(threshold)
+
+    # if percentage_used >= threshold:
+        # slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
+        # github_service.modify_gha_minutes_quota_threshold(threshold + 10)
 
 if __name__ == "__main__":
     alert_on_low_github_actions_quota()

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -46,8 +46,8 @@ def alert_on_low_quota():
 
     threshold = github_service.get_gha_minutes_quota_threshold()
 
-    if percentage_used >= 1:
-        # slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
+    if percentage_used >= threshold:
+        slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
         github_service.modify_gha_minutes_quota_threshold(threshold + 10)
 
 if __name__ == "__main__":

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -1,6 +1,7 @@
 from services.github_service import GithubService
 from config.constants import ENTERPRISE, MINISTRY_OF_JUSTICE, SLACK_CHANNEL
 import os
+import sys
 from services.slack_service import SlackService
 
 def calculate_percentage_used(total_minutes_used):
@@ -13,7 +14,13 @@ def low_threshold_triggered_message(percentage_used):
 
 def alert_on_low_quota():
     github_token = os.environ.get("GH_TOKEN")
+    if github_token is None:
+        print("No GITHUB_TOKEN environment variable set")
+        sys.exit(1)
     slack_token = os.environ.get("ADMIN_SLACK_TOKEN")
+    if slack_token is None:
+        print("No SLACK_TOKEN environment variable set")
+        sys.exit(1)
 
     github_service = GithubService(github_token, MINISTRY_OF_JUSTICE, ENTERPRISE)
     slack_service = SlackService(slack_token)

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -11,16 +11,6 @@ def calculate_percentage_used(total_minutes_used):
 def low_threshold_triggered_message(percentage_used):
     return f"Warning:\n\n {round(100 - percentage_used, 1)}% of the Github Actions minutes quota remains."
 
-def calculate_total_minutes_used(organisations, github_service):
-    total = 0 
-    
-    for org in organisations:
-        billing_data = github_service.get_gha_minutes_used_for_organisation(org)
-        minutes_used = billing_data["total_minutes_used"]
-        total += minutes_used
-
-    return total
-
 def alert_on_low_quota():
     github_token = os.environ.get("GH_TOKEN")
     slack_token = os.environ.get("ADMIN_SLACK_TOKEN")
@@ -30,7 +20,7 @@ def alert_on_low_quota():
     
     organisations = github_service.get_all_organisations_in_enterprise()
 
-    total_minutes_used = calculate_total_minutes_used(organisations, github_service)
+    total_minutes_used = github_service.calculate_total_minutes_used(organisations)
 
     percentage_used = calculate_percentage_used(total_minutes_used)
 

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -7,9 +7,9 @@ import datetime
 import time
 
 def reset_alerting_threshold_if_first_day_of_month(github_service):
-    base_alerting_threshold = 70
+    base_alerting_threshold = 7
 
-    if datetime.date.today().day == 1:
+    if datetime.date.today().day == 14:
         github_service.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
 def calculate_percentage_used(total_minutes_used):

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -4,7 +4,6 @@ import os
 import json
 from services.slack_service import SlackService
 import datetime
-import time
 
 def reset_alerting_threshold_if_first_day_of_month(github_service):
     base_alerting_threshold = 70

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -24,12 +24,9 @@ def calculate_total_minutes_used(organisations, github_service):
     
     for org in organisations:
         billing_data = github_service.get_gha_minutes_used_for_organisation(org.login)
-        # processed_data = json.loads(billing_data)
         minutes_used = billing_data["total_minutes_used"]
         total += minutes_used
 
-    print(total)
-    
     return total
 
 def alert_on_low_quota():
@@ -49,8 +46,8 @@ def alert_on_low_quota():
 
     threshold = github_service.get_gha_minutes_quota_threshold()
 
-    if percentage_used >= threshold:
-        slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
+    if percentage_used >= 1:
+        # slack_service.send_message_to_plaintext_channel_name(low_threshold_triggered_message(percentage_used), SLACK_CHANNEL)
         github_service.modify_gha_minutes_quota_threshold(threshold + 10)
 
 if __name__ == "__main__":

--- a/bin/alert_on_low_github_actions_quota.py
+++ b/bin/alert_on_low_github_actions_quota.py
@@ -1,7 +1,6 @@
 from services.github_service import GithubService
 from config.constants import ENTERPRISE, MINISTRY_OF_JUSTICE, SLACK_CHANNEL
 import os
-import json
 from services.slack_service import SlackService
 import datetime
 
@@ -23,7 +22,7 @@ def calculate_total_minutes_used(organisations, github_service):
     total = 0 
     
     for org in organisations:
-        billing_data = github_service.get_gha_minutes_used_for_organisation(org.login)
+        billing_data = github_service.get_gha_minutes_used_for_organisation(org)
         minutes_used = billing_data["total_minutes_used"]
         total += minutes_used
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1243,7 +1243,7 @@ class GithubService:
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
             "-f", "name='GHA_MINUTES_QUOTA_THRESHOLD'",
-            "-f", f"value='{new_threshold}'"
+            "-f", f"value='{str(new_threshold)}'"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,7 +1242,7 @@ class GithubService:
             "-H", "Accept: application/vnd.github+json",
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", f"value='{str(new_threshold)}'"
+            "-f", f"value='{new_threshold}'"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,7 +1242,7 @@ class GithubService:
             "-H", "Accept: application/vnd.github+json",
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", f"value=\'{str(new_threshold)}\'"
+            "-f", f"value='{str(new_threshold)}'"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1251,3 +1251,13 @@ class GithubService:
         if date.today().day == 1:
             self.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def calculate_total_minutes_used(self, organisations):
+        total = 0 
+        
+        for org in organisations:
+            billing_data = self.get_gha_minutes_used_for_organisation(org)
+            minutes_used = billing_data["total_minutes_used"]
+            total += minutes_used
+
+        return total

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1250,5 +1250,5 @@ class GithubService:
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
-        return repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD").value
+        return int(repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD").value)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1268,7 +1268,9 @@ class GithubService:
 
         total_minutes_used = self.calculate_total_minutes_used(organisations)
 
-        percentage_used = (total_minutes_used / 50000) * 100
+        total_quota = 50000
+
+        percentage_used = (total_minutes_used / total_quota) * 100
 
         self.reset_alerting_threshold_if_first_day_of_month()
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1219,9 +1219,9 @@ class GithubService:
 
         response = self.github_client_rest_api.get(f"https://api.github.com/orgs/{organization}/settings/billing/actions", headers=headers)
 
-        print(response)
+        print(response.json())
 
-        return response
+        return response.json()
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_all_organisations_in_enterprise(self) -> list[Organization]:

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1243,7 +1243,7 @@ class GithubService:
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
             "-f", "name='GHA_MINUTES_QUOTA_THRESHOLD'",
-            "-f", f"{new_threshold}"
+            "-f", f"value={new_threshold}"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1246,3 +1246,9 @@ class GithubService:
         ]       
         
         subprocess.run(command)
+
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def get_gha_minutes_quota_threshold(self):
+        repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
+        return repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD").value
+

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,7 +1242,7 @@ class GithubService:
             "-H", "Accept: application/vnd.github+json",
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", "name='GHA_MINUTES_QUOTA_THRESHOLD'",
+            "-f", "'GHA_MINUTES_QUOTA_THRESHOLD'",
             "-f", f"value='{str(new_threshold)}'"
         ]       
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1231,24 +1231,23 @@ class GithubService:
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
 
-        # headers = {
-        #     "Accept": "application/vnd.github+json",
-        #     "X-GitHub-Api-Version": "2022-11-28"
-        # }
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
 
-        # payload = { 'value' : f"{new_threshold}" }
+        payload = { 'value' : f"{new_threshold}" }
 
-        # response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
 
-        # print(response.status_code)
-        # print(response.text)
+        print(response.status_code)
+        print(response.text)
 
-        repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
-        actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        print(actions_variable.value)
-        response = actions_variable.edit(value=str(new_threshold))
+        # repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
+        # actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
+        # response = actions_variable.edit(value=str(new_threshold))
 
-        print(response)
+        # print(response)
         
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1237,5 +1237,4 @@ class GithubService:
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        print(actions_variable.value)
-        # actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", str(new_threshold))
+        actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", str(new_threshold))

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1231,17 +1231,23 @@ class GithubService:
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
 
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28"
-        }
+        # headers = {
+        #     "Accept": "application/vnd.github+json",
+        #     "X-GitHub-Api-Version": "2022-11-28"
+        # }
 
-        payload = { 'value' : f"{new_threshold}" }
+        # payload = { 'value' : f"{new_threshold}" }
 
-        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+        # response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
 
-        print(response.status_code)
-        print(response.text)
+        # print(response.status_code)
+        # print(response.text)
+
+        repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
+        actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
+        response = actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", new_threshold)
+
+        print(response)
         
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1245,7 +1245,7 @@ class GithubService:
 
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        response = actions_variable.edit('value', str(new_threshold))
+        response = actions_variable.edit(value=str(new_threshold))
 
         print(response)
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1237,5 +1237,5 @@ class GithubService:
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        print(actions_variable)
+        print(actions_variable.value)
         # actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", str(new_threshold))

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1243,7 +1243,7 @@ class GithubService:
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
             "-f", "name='GHA_MINUTES_QUOTA_THRESHOLD'",
-            "-f", f"value={new_threshold}"
+            "-f", f"value='{new_threshold}'"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1245,7 +1245,7 @@ class GithubService:
 
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        response = actions_variable.edit(str(new_threshold))
+        response = actions_variable.edit('value', str(new_threshold))
 
         print(response)
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1237,4 +1237,4 @@ class GithubService:
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", str(new_threshold))
+        actions_variable.edit(str(new_threshold))

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1236,9 +1236,9 @@ class GithubService:
             "X-GitHub-Api-Version": "2022-11-28"
         }
 
-        payload = { 'value' : f"{new_threshold}" }
+        payload = { 'value' : new_threshold }
 
-        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", json.dump(payload), headers=headers)
 
         print(response.status_code)
         print(response.text)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1217,7 +1217,7 @@ class GithubService:
             "X-GitHub-Api-Version": "2022-11-28"
         }
 
-        response = self.github_client_rest_api.get(f"/orgs/{organization}/settings/billing/actions", headers=headers)
+        response = self.github_client_rest_api.get(f"https://api.github.com/orgs/{organization}/settings/billing/actions", headers=headers)
 
         print(response)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1238,7 +1238,7 @@ class GithubService:
 
         payload = { 'value' : new_threshold }
 
-        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", json.dump(payload), headers=headers)
+        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", json.dumps(payload), headers=headers)
 
         print(response.status_code)
         print(response.text)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1238,16 +1238,7 @@ class GithubService:
 
         payload = { 'value' : str(new_threshold) }
 
-        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", json.dumps(payload), headers=headers)
-
-        print(response.status_code)
-        print(response.text)
-
-        # repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
-        # actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        # response = actions_variable.edit(value=str(new_threshold))
-
-        # print(response)
+        self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", json.dumps(payload), headers=headers)
         
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1236,9 +1236,9 @@ class GithubService:
             "X-GitHub-Api-Version": "2022-11-28"
         }
 
-        payload = {'name': 'GHA_MINUTES_QUOTA_THRESHOLD', 'value' : f"{new_threshold}" }
+        payload = { 'value' : f"{new_threshold}" }
 
-        self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+        self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", data=payload, headers=headers)
         
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1211,20 +1211,17 @@ class GithubService:
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_used_for_organisation(self, organization) -> int:
         logging.info(f"Getting all github actions minutes used for organization {organization}")
-        command = [
-            "gh", 
-            "api",
-            "-H", "Accept: application/vnd.github+json",
-            "-H", "X-GitHub-Api-Version: 2022-11-28",
-            f"/orgs/{organization}/settings/billing/actions"
-        ]       
 
-        try:
-            result = subprocess.run(command, capture_output=True, text=True, check=True)
-            output = result.stdout.strip()
-            return output
-        except subprocess.CalledProcessError as e:
-            print(f"(Warning) Couldn't get billing data:\norganization: {organization}\nreturncode: {e.returncode}\noutput: {e.output}")
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+
+        response = self.github_client_rest_api.get(f"/orgs/{organization}/settings/billing/actions", headers=headers)
+
+        print(response)
+
+        return response
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_all_organisations_in_enterprise(self) -> list[Organization]:

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1236,7 +1236,7 @@ class GithubService:
             "X-GitHub-Api-Version": "2022-11-28"
         }
 
-        payload = {'value' : f"{new_threshold}" }
+        payload = {'name': 'GHA_MINUTES_QUOTA_THRESHOLD', 'value' : f"{new_threshold}" }
 
         self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,7 +1242,7 @@ class GithubService:
             "-H", "Accept: application/vnd.github+json",
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", f"value='{new_threshold}'"
+            "-f", f"value={new_threshold}"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1245,7 +1245,7 @@ class GithubService:
 
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        response = actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", new_threshold)
+        response = actions_variable.edit(new_threshold)
 
         print(response)
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1238,7 +1238,7 @@ class GithubService:
 
         payload = {'value' : f"{new_threshold}" }
 
-        self.github_client_rest_api.patch("/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+        self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
         
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1261,3 +1261,20 @@ class GithubService:
             total += minutes_used
 
         return total
+    
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def check_if_quota_is_low(self):
+        organisations = self.get_all_organisations_in_enterprise()
+
+        total_minutes_used = self.calculate_total_minutes_used(organisations)
+
+        percentage_used = (total_minutes_used / 50000) * 100
+
+        self.reset_alerting_threshold_if_first_day_of_month()
+
+        threshold = self.get_gha_minutes_quota_threshold()
+
+        if percentage_used >= threshold:
+            return { 'threshold': threshold, 'percentage_used': percentage_used }
+        else:
+            return False

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1219,8 +1219,6 @@ class GithubService:
 
         response = self.github_client_rest_api.get(f"https://api.github.com/orgs/{organization}/settings/billing/actions", headers=headers)
 
-        print(response.json())
-
         return response.json()
 
     @retries_github_rate_limit_exception_at_next_reset_once
@@ -1232,18 +1230,16 @@ class GithubService:
     @retries_github_rate_limit_exception_at_next_reset_once
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
-        command = [
-            "gh", 
-            "api",
-            "--method", "PATCH",
-            "-H", "Accept: application/vnd.github+json",
-            "-H", "X-GitHub-Api-Version: 2022-11-28",
-            "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", f"value={new_threshold}"
-        ]       
-        
-        subprocess.run(command)
 
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+
+        payload = {'value' : f"{new_threshold}" }
+
+        self.github_client_rest_api.patch("/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+        
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,8 +1242,8 @@ class GithubService:
             "-H", "Accept: application/vnd.github+json",
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", "'GHA_MINUTES_QUOTA_THRESHOLD'",
-            "-f", f"value='{str(new_threshold)}'"
+            "-f", "name=\'GHA_MINUTES_QUOTA_THRESHOLD\'",
+            "-f", f"value=\'{str(new_threshold)}\'"
         ]       
         
         subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1236,7 +1236,7 @@ class GithubService:
             "X-GitHub-Api-Version": "2022-11-28"
         }
 
-        payload = { 'value' : new_threshold }
+        payload = { 'value' : str(new_threshold) }
 
         response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", json.dumps(payload), headers=headers)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1245,6 +1245,7 @@ class GithubService:
 
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
+        print(actions_variable.value)
         response = actions_variable.edit(value=str(new_threshold))
 
         print(response)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1245,7 +1245,7 @@ class GithubService:
 
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
         actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        response = actions_variable.edit(new_threshold)
+        response = actions_variable.edit(str(new_threshold))
 
         print(response)
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1235,6 +1235,15 @@ class GithubService:
     @retries_github_rate_limit_exception_at_next_reset_once
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
-        repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
-        actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
-        actions_variable.edit(str(new_threshold))
+        command = [
+            "gh", 
+            "api",
+            "--method", "PATCH",
+            "-H", "Accept: application/vnd.github+json",
+            "-H", "X-GitHub-Api-Version: 2022-11-28",
+            "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
+            "-f", "name='GHA_MINUTES_QUOTA_THRESHOLD'",
+            "-f", f"{new_threshold}"
+        ]       
+        
+        subprocess.run(command)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1238,7 +1238,10 @@ class GithubService:
 
         payload = { 'value' : f"{new_threshold}" }
 
-        self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", data=payload, headers=headers)
+        response = self.github_client_rest_api.patch("https://api.github.com/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD", payload, headers=headers)
+
+        print(response.status_code)
+        print(response.text)
         
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_gha_minutes_quota_threshold(self):

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1,6 +1,6 @@
 import json
 from calendar import timegm
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from textwrap import dedent
 from time import gmtime, sleep
 from typing import Any, Callable
@@ -1243,4 +1243,11 @@ class GithubService:
     def get_gha_minutes_quota_threshold(self):
         actions_variable = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering').get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
         return int(actions_variable.value)
+    
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def reset_alerting_threshold_if_first_day_of_month(self):
+        base_alerting_threshold = 70
+
+        if date.today().day == 1:
+            self.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,7 +1242,6 @@ class GithubService:
             "-H", "Accept: application/vnd.github+json",
             "-H", "X-GitHub-Api-Version: 2022-11-28",
             "/repos/ministryofjustice/operations-engineering/actions/variables/GHA_MINUTES_QUOTA_THRESHOLD",
-            "-f", "name=\'GHA_MINUTES_QUOTA_THRESHOLD\'",
             "-f", f"value=\'{str(new_threshold)}\'"
         ]       
         

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1236,6 +1236,6 @@ class GithubService:
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
         repo = self.github_client_core_api.get_repo('ministryofjustice/operations-engineering')
-        actions_variable = repo.get_workflow_variable("GHA_MINUTES_QUOTA_THRESHOLD")
+        actions_variable = repo.get_variable("GHA_MINUTES_QUOTA_THRESHOLD")
         print(actions_variable)
         # actions_variable.edit("GHA_MINUTES_QUOTA_THRESHOLD", str(new_threshold))

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -47,6 +47,8 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
 
         self.assertEqual(calculate_total_minutes_used(["org1", "org2"], GithubService), 20)
 
+
+    @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
     @patch("github.Github.__new__")
     @patch("bin.alert_on_low_github_actions_quota.low_threshold_triggered_message")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
@@ -80,6 +82,7 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
         mock_send_message_to_plaintext_channel_name.assert_called_once_with(f"Warning:\n\n 25% of the Github Actions minutes quota remains.", "operations-engineering-alerts")
         mock_modify_gha_minutes_quota_threshold.assert_called_once_with(80)
 
+    @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
     @patch("github.Github.__new__")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from bin.alert_on_low_github_actions_quota import (
-    calculate_percentage_used,
     low_threshold_triggered_message,
     alert_on_low_quota 
 )
@@ -12,10 +11,6 @@ from services.slack_service import SlackService
 
 
 class TestGithubACtionsQuotaAlerting(unittest.TestCase):
-
-    def test_calculate_percentage_used(self):
-
-        self.assertEqual(calculate_percentage_used(5000), 10)
 
     def test_low_threshold_triggered_message(self):
 
@@ -27,32 +22,24 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
     @patch("bin.alert_on_low_github_actions_quota.low_threshold_triggered_message")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")
-    @patch.object(GithubService, "get_gha_minutes_quota_threshold")
-    @patch.object(GithubService, "reset_alerting_threshold_if_first_day_of_month")
-    @patch("bin.alert_on_low_github_actions_quota.calculate_percentage_used")
-    @patch.object(GithubService, "calculate_total_minutes_used")
-    @patch.object(GithubService, "get_all_organisations_in_enterprise")
+    @patch.object(GithubService, "check_if_quota_is_low")
+    @patch('os.environ')
     def test_alert_on_low_quota_if_low(self, 
-        mock_get_all_organisations_in_enterprise, 
-        mock_calculate_total_minutes_used, 
-        mock_calculate_percentage_used, 
-        mock_reset_alerting_threshold_if_first_day_of_month,
-        mock_get_gha_minutes_quota_threshold, 
+        mock_env,
+        mock_check_if_quota_is_low,
         mock_send_message_to_plaintext_channel_name,
         mock_modify_gha_minutes_quota_threshold,
         mock_low_threshold_triggered_message,
         mock_github_client_core_api
     ):
 
-        mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
-        mock_calculate_total_minutes_used.return_value = 37500
-        mock_calculate_percentage_used.return_value = 75
-        mock_get_gha_minutes_quota_threshold.return_value = 70
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_TOKEN', 'ADMIN_SLACK_TOKEN'] else None
+        mock_check_if_quota_is_low.return_value = { 'threshold': 70, 'percentage_used': 75 }
         mock_low_threshold_triggered_message.return_value = f"Warning:\n\n 25% of the Github Actions minutes quota remains."
 
         alert_on_low_quota()
 
-        mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
+        mock_check_if_quota_is_low.assert_called_once()
         mock_send_message_to_plaintext_channel_name.assert_called_once_with(f"Warning:\n\n 25% of the Github Actions minutes quota remains.", "operations-engineering-alerts")
         mock_modify_gha_minutes_quota_threshold.assert_called_once_with(80)
 
@@ -61,30 +48,22 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
     @patch("github.Github.__new__")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")
-    @patch.object(GithubService, "get_gha_minutes_quota_threshold")
-    @patch.object(GithubService, "reset_alerting_threshold_if_first_day_of_month")
-    @patch("bin.alert_on_low_github_actions_quota.calculate_percentage_used")
-    @patch.object(GithubService, "calculate_total_minutes_used")
-    @patch.object(GithubService, "get_all_organisations_in_enterprise")
-    def test_alert_on_low_quota_if_not_low(self, 
-        mock_get_all_organisations_in_enterprise, 
-        mock_calculate_total_minutes_used, 
-        mock_calculate_percentage_used, 
-        mock_reset_alerting_threshold_if_first_day_of_month,
-        mock_get_gha_minutes_quota_threshold, 
+    @patch.object(GithubService, "check_if_quota_is_low")
+    @patch('os.environ')
+    def test_alert_on_low_quota_if_not_low(self,
+        mock_env, 
+        mock_check_if_quota_is_low,
         mock_send_message_to_plaintext_channel_name,
         mock_modify_gha_minutes_quota_threshold,
         mock_github_client_core_api
     ):
 
-        mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
-        mock_calculate_total_minutes_used.return_value = 5000
-        mock_calculate_percentage_used.return_value = 10
-        mock_get_gha_minutes_quota_threshold.return_value = 70
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_TOKEN', 'ADMIN_SLACK_TOKEN'] else None
+        mock_check_if_quota_is_low.return_value = False
 
         alert_on_low_quota()
 
-        mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
+        mock_check_if_quota_is_low.assert_called_once()
         assert not mock_send_message_to_plaintext_channel_name.called
         assert not mock_modify_gha_minutes_quota_threshold.called
         

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from freezegun import freeze_time
+
+from bin.alert_on_low_github_actions_quota import ( 
+    reset_alerting_threshold_if_first_day_of_month, 
+    calculate_percentage_used,
+    low_threshold_triggered_message,
+    calculate_total_minutes_used,
+    alert_on_low_quota 
+)
+
+from services.github_service import GithubService
+from services.slack_service import SlackService
+
+
+class TestGithubACtionsQuotaAlerting(unittest.TestCase):
+
+    @freeze_time("2021-02-01")
+    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
+    def test_reset_alerting_threshold_if_first_day_of_month(self, mock_modify_gha_minutes_quota_threshold):
+
+        reset_alerting_threshold_if_first_day_of_month(GithubService)
+
+        mock_modify_gha_minutes_quota_threshold.assert_called_once_with(70)
+
+    @freeze_time("2021-02-22")
+    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
+    def test_reset_alerting_threshold_if_not_first_day_of_month(self, mock_modify_gha_minutes_quota_threshold):
+
+        reset_alerting_threshold_if_first_day_of_month(GithubService)
+
+        assert not mock_modify_gha_minutes_quota_threshold.called
+
+    def test_calculate_percentage_used(self):
+
+        self.assertEqual(calculate_percentage_used(5000), 10)
+
+    def test_low_threshold_triggered_message(self):
+
+        self.assertEqual(low_threshold_triggered_message(10), f"Warning:\n\n 90% of the Github Actions minutes quota remains.")
+
+    @patch.object(GithubService, "get_gha_minutes_used_for_organisation")
+    def test_calculate_total_minutes_used(self, mock_get_gha_minutes_used_for_organisation):
+
+        mock_get_gha_minutes_used_for_organisation.return_value = { "total_minutes_used": 10 }
+
+        self.assertEqual(calculate_total_minutes_used(["org1", "org2"], GithubService), 20)
+
+    @patch("bin.alert_on_low_github_actions_quota.low_threshold_triggered_message")
+    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
+    @patch.object(SlackService, "send_message_to_plaintext_channel_name")
+    @patch.object(GithubService, "get_gha_minutes_quota_threshold")
+    @patch("bin.alert_on_low_github_actions_quota.reset_alerting_threshold_if_first_day_of_month")
+    @patch("bin.alert_on_low_github_actions_quota.calculate_percentage_used")
+    @patch("bin.alert_on_low_github_actions_quota.calculate_total_minutes_used")
+    @patch.object(GithubService, "get_all_organisations_in_enterprise")
+    def test_alert_on_low_quota_if_low(self, 
+        mock_get_all_organisations_in_enterprise, 
+        mock_calculate_total_minutes_used, 
+        mock_calculate_percentage_used, 
+        mock_reset_alerting_threshold_if_first_day_of_month,
+        mock_get_gha_minutes_quota_threshold, 
+        mock_send_message_to_plaintext_channel_name,
+        mock_modify_gha_minutes_quota_threshold,
+        mock_low_threshold_triggered_message
+    ):
+
+        mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
+        mock_calculate_total_minutes_used.return_value = 37500
+        mock_calculate_percentage_used.return_value = 75
+        mock_get_gha_minutes_quota_threshold.return_value = 70
+        mock_low_threshold_triggered_message.return_value = f"Warning:\n\n 25% of the Github Actions minutes quota remains."
+
+        alert_on_low_quota()
+
+        mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
+        mock_send_message_to_plaintext_channel_name.assert_called_once_with(f"Warning:\n\n 25% of the Github Actions minutes quota remains.", "operations-engineering-alerts")
+        mock_modify_gha_minutes_quota_threshold.assert_called_once_with(80)
+
+    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
+    @patch.object(SlackService, "send_message_to_plaintext_channel_name")
+    @patch.object(GithubService, "get_gha_minutes_quota_threshold")
+    @patch("bin.alert_on_low_github_actions_quota.reset_alerting_threshold_if_first_day_of_month")
+    @patch("bin.alert_on_low_github_actions_quota.calculate_percentage_used")
+    @patch("bin.alert_on_low_github_actions_quota.calculate_total_minutes_used")
+    @patch.object(GithubService, "get_all_organisations_in_enterprise")
+    def test_alert_on_low_quota_if_not_low(self, 
+        mock_get_all_organisations_in_enterprise, 
+        mock_calculate_total_minutes_used, 
+        mock_calculate_percentage_used, 
+        mock_reset_alerting_threshold_if_first_day_of_month,
+        mock_get_gha_minutes_quota_threshold, 
+        mock_send_message_to_plaintext_channel_name,
+        mock_modify_gha_minutes_quota_threshold
+    ):
+
+        mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
+        mock_calculate_total_minutes_used.return_value = 5000
+        mock_calculate_percentage_used.return_value = 10
+        mock_get_gha_minutes_quota_threshold.return_value = 70
+
+        alert_on_low_quota()
+
+        mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
+        assert not mock_send_message_to_plaintext_channel_name.called
+        assert not mock_modify_gha_minutes_quota_threshold.called
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -47,6 +47,7 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
 
         self.assertEqual(calculate_total_minutes_used(["org1", "org2"], GithubService), 20)
 
+    @patch("github.Github.__new__")
     @patch("bin.alert_on_low_github_actions_quota.low_threshold_triggered_message")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")
@@ -63,7 +64,8 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
         mock_get_gha_minutes_quota_threshold, 
         mock_send_message_to_plaintext_channel_name,
         mock_modify_gha_minutes_quota_threshold,
-        mock_low_threshold_triggered_message
+        mock_low_threshold_triggered_message,
+        mock_github_client_core_api
     ):
 
         mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
@@ -78,6 +80,7 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
         mock_send_message_to_plaintext_channel_name.assert_called_once_with(f"Warning:\n\n 25% of the Github Actions minutes quota remains.", "operations-engineering-alerts")
         mock_modify_gha_minutes_quota_threshold.assert_called_once_with(80)
 
+    @patch("github.Github.__new__")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")
     @patch.object(GithubService, "get_gha_minutes_quota_threshold")
@@ -92,7 +95,8 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
         mock_reset_alerting_threshold_if_first_day_of_month,
         mock_get_gha_minutes_quota_threshold, 
         mock_send_message_to_plaintext_channel_name,
-        mock_modify_gha_minutes_quota_threshold
+        mock_modify_gha_minutes_quota_threshold,
+        mock_github_client_core_api
     ):
 
         mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -28,9 +28,9 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")
     @patch.object(GithubService, "get_gha_minutes_quota_threshold")
-    @patch("bin.alert_on_low_github_actions_quota.reset_alerting_threshold_if_first_day_of_month")
+    @patch.object(GithubService, "reset_alerting_threshold_if_first_day_of_month")
     @patch("bin.alert_on_low_github_actions_quota.calculate_percentage_used")
-    @patch("bin.alert_on_low_github_actions_quota.calculate_total_minutes_used")
+    @patch.object(GithubService, "calculate_total_minutes_used")
     @patch.object(GithubService, "get_all_organisations_in_enterprise")
     def test_alert_on_low_quota_if_low(self, 
         mock_get_all_organisations_in_enterprise, 
@@ -62,9 +62,9 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")
     @patch.object(GithubService, "get_gha_minutes_quota_threshold")
-    @patch("bin.alert_on_low_github_actions_quota.reset_alerting_threshold_if_first_day_of_month")
+    @patch.object(GithubService, "reset_alerting_threshold_if_first_day_of_month")
     @patch("bin.alert_on_low_github_actions_quota.calculate_percentage_used")
-    @patch("bin.alert_on_low_github_actions_quota.calculate_total_minutes_used")
+    @patch.object(GithubService, "calculate_total_minutes_used")
     @patch.object(GithubService, "get_all_organisations_in_enterprise")
     def test_alert_on_low_quota_if_not_low(self, 
         mock_get_all_organisations_in_enterprise, 

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -1,9 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from freezegun import freeze_time
 
-from bin.alert_on_low_github_actions_quota import ( 
-    reset_alerting_threshold_if_first_day_of_month, 
+from bin.alert_on_low_github_actions_quota import (
     calculate_percentage_used,
     low_threshold_triggered_message,
     calculate_total_minutes_used,
@@ -15,22 +13,6 @@ from services.slack_service import SlackService
 
 
 class TestGithubACtionsQuotaAlerting(unittest.TestCase):
-
-    @freeze_time("2021-02-01")
-    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
-    def test_reset_alerting_threshold_if_first_day_of_month(self, mock_modify_gha_minutes_quota_threshold):
-
-        reset_alerting_threshold_if_first_day_of_month(GithubService)
-
-        mock_modify_gha_minutes_quota_threshold.assert_called_once_with(70)
-
-    @freeze_time("2021-02-22")
-    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
-    def test_reset_alerting_threshold_if_not_first_day_of_month(self, mock_modify_gha_minutes_quota_threshold):
-
-        reset_alerting_threshold_if_first_day_of_month(GithubService)
-
-        assert not mock_modify_gha_minutes_quota_threshold.called
 
     def test_calculate_percentage_used(self):
 

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -49,6 +49,7 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
 
 
     @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+    @patch("gql.Client.__new__", new=MagicMock)
     @patch("github.Github.__new__")
     @patch("bin.alert_on_low_github_actions_quota.low_threshold_triggered_message")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
@@ -83,6 +84,7 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
         mock_modify_gha_minutes_quota_threshold.assert_called_once_with(80)
 
     @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+    @patch("gql.Client.__new__", new=MagicMock)
     @patch("github.Github.__new__")
     @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
     @patch.object(SlackService, "send_message_to_plaintext_channel_name")

--- a/test/test_bin/test_alert_on_low_github_actions_quota.py
+++ b/test/test_bin/test_alert_on_low_github_actions_quota.py
@@ -4,7 +4,6 @@ from unittest.mock import patch, MagicMock
 from bin.alert_on_low_github_actions_quota import (
     calculate_percentage_used,
     low_threshold_triggered_message,
-    calculate_total_minutes_used,
     alert_on_low_quota 
 )
 
@@ -21,14 +20,6 @@ class TestGithubACtionsQuotaAlerting(unittest.TestCase):
     def test_low_threshold_triggered_message(self):
 
         self.assertEqual(low_threshold_triggered_message(10), f"Warning:\n\n 90% of the Github Actions minutes quota remains.")
-
-    @patch.object(GithubService, "get_gha_minutes_used_for_organisation")
-    def test_calculate_total_minutes_used(self, mock_get_gha_minutes_used_for_organisation):
-
-        mock_get_gha_minutes_used_for_organisation.return_value = { "total_minutes_used": 10 }
-
-        self.assertEqual(calculate_total_minutes_used(["org1", "org2"], GithubService), 20)
-
 
     @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
     @patch("gql.Client.__new__", new=MagicMock)

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2060,5 +2060,23 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
         self.assertEqual(70, response)
 
+    @freeze_time("2021-02-01")
+    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
+    def test_reset_alerting_threshold_if_first_day_of_month(self, mock_modify_gha_minutes_quota_threshold, mock_github_client_rest_api, mock_github_client_core_api):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        github_service.reset_alerting_threshold_if_first_day_of_month()
+
+        mock_modify_gha_minutes_quota_threshold.assert_called_once_with(70)
+
+    @freeze_time("2021-02-22")
+    @patch.object(GithubService, "modify_gha_minutes_quota_threshold")
+    def test_reset_alerting_threshold_if_not_first_day_of_month(self, mock_modify_gha_minutes_quota_threshold, mock_github_client_rest_api, mock_github_client_core_api):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        github_service.reset_alerting_threshold_if_first_day_of_month()
+
+        assert not mock_modify_gha_minutes_quota_threshold.called
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2019,7 +2019,6 @@ class TestNewOwnerDetected(unittest.TestCase):
         self.assertEqual(result[1]['userLogin'], 'new_member2')
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
-@patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__")
 @patch("requests.sessions.Session.__new__")
 class TestGHAMinutesQuotaOperations(unittest.TestCase):

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2078,5 +2078,13 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
         assert not mock_modify_gha_minutes_quota_threshold.called
 
+    @patch.object(GithubService, "get_gha_minutes_used_for_organisation")
+    def test_calculate_total_minutes_used(self, mock_get_gha_minutes_used_for_organisation, mock_github_client_rest_api, mock_github_client_core_api):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        mock_get_gha_minutes_used_for_organisation.return_value = { "total_minutes_used": 10 }
+
+        self.assertEqual(github_service.calculate_total_minutes_used(["org1", "org2"]), 20)
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2018,6 +2018,8 @@ class TestNewOwnerDetected(unittest.TestCase):
         self.assertEqual(result[1]['actorLogin'], 'user2')
         self.assertEqual(result[1]['userLogin'], 'new_member2')
 
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__")
 @patch("requests.sessions.Session.__new__")
 class TestGHAMinutesQuotaOperations(unittest.TestCase):

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2019,6 +2019,7 @@ class TestNewOwnerDetected(unittest.TestCase):
         self.assertEqual(result[1]['userLogin'], 'new_member2')
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__")
 @patch("requests.sessions.Session.__new__")
 class TestGHAMinutesQuotaOperations(unittest.TestCase):

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1,5 +1,4 @@
 import unittest
-import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, call, patch

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2086,5 +2086,52 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
         self.assertEqual(github_service.calculate_total_minutes_used(["org1", "org2"]), 20)
 
+    @patch.object(GithubService, "get_gha_minutes_quota_threshold")
+    @patch.object(GithubService, "reset_alerting_threshold_if_first_day_of_month")
+    @patch.object(GithubService, "calculate_total_minutes_used")
+    @patch.object(GithubService, "get_all_organisations_in_enterprise")
+    def test_alert_on_low_quota_if_low(self, 
+        mock_get_all_organisations_in_enterprise, 
+        mock_calculate_total_minutes_used,
+        mock_reset_alerting_threshold_if_first_day_of_month,
+        mock_get_gha_minutes_quota_threshold,
+        mock_github_client_rest_api, 
+        mock_github_client_core_api
+    ):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
+        mock_calculate_total_minutes_used.return_value = 37500
+        mock_get_gha_minutes_quota_threshold.return_value = 70
+
+        result = github_service.check_if_quota_is_low()
+
+        mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
+        self.assertEqual(result['threshold'], 70)
+        self.assertEqual(result['percentage_used'], 75)
+
+    @patch.object(GithubService, "get_gha_minutes_quota_threshold")
+    @patch.object(GithubService, "reset_alerting_threshold_if_first_day_of_month")
+    @patch.object(GithubService, "calculate_total_minutes_used")
+    @patch.object(GithubService, "get_all_organisations_in_enterprise")
+    def test_alert_on_low_quota_if_not_low(self, 
+        mock_get_all_organisations_in_enterprise, 
+        mock_calculate_total_minutes_used,
+        mock_reset_alerting_threshold_if_first_day_of_month,
+        mock_get_gha_minutes_quota_threshold,
+        mock_github_client_rest_api, 
+        mock_github_client_core_api
+    ):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        mock_get_all_organisations_in_enterprise.return_value = ["org1", "org2"]
+        mock_calculate_total_minutes_used.return_value = 5000
+        mock_get_gha_minutes_quota_threshold.return_value = 70
+
+        result = github_service.check_if_quota_is_low()
+
+        mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
+        self.assertEqual(result, False)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Alerting system for github actions minutes quota usage**

**Github Service**
- get_all_organisations_in_enterprise
- get_gha_minutes_used_for_organisation 
- get_gha_minutes_quota_threshold
- modify_gha_minutes_quota_threshold
*** these pretty much do what their names suggest, subprocess was used in place of PyGithub where the correct functionality was not found in PyGithub. ***

**alert_on_low_github_actions_quota** job in **bin**
- Configure tokens
- Configure services
- Get all orgs in the enterprise
- Get all minutes used by all orgs in enterprise
- Calculate percentage of minutes used
- Reset alerting threshold if first day of month
- Retrieve alerting threshold from Github Actions Variable
- Compare % minutes used to threshold 
- Trigger Slack alert and increment threshold if threshold met or exceeded 
