### PR TITLE
Get users from multiple organisations

### DIFF
--- a/services/github_service.py
+++ b/services/github_service.py
@@ -267,14 +267,14 @@ class GithubService:
     def __get_all_users(self) -> list:
         logging.info("Getting all organization members")
         return self.github_client_core_api.get_organization(self.organisation_name).get_members() or []
-    
+
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_users_of_multiple_organisations(self, organisations: list) -> list:
         combined_users = []
-        for org in organisations:   
+        for org in organisations:
             combined_users = combined_users + self.github_client_core_api.get_organization(org).get_members()
         return combined_users
-    
+
     @retries_github_rate_limit_exception_at_next_reset_once
     def __add_user_to_team(self, user: NamedUser, team_id: int) -> None:
         logging.info(f"Adding user {user.name} to team {team_id}")

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -270,10 +270,11 @@ class GithubService:
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_users_of_multiple_organisations(self, organisations: list) -> list:
-        users = []
+        all_users = []
         for org in organisations:
-            [users.append(user['login']) for user in self.github_client_core_api.get_organization(org).get_members() if user['login'] not in users]
-        return users
+            org_users = [user["login"] for user in self.github_client_core_api.get_organization(org).get_members() if user['login'] not in all_users]
+            all_users = all_users + org_users
+        return all_users
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def __add_user_to_team(self, user: NamedUser, team_id: int) -> None:

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -270,9 +270,9 @@ class GithubService:
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_users_of_multiple_organisations(self, organisations: list) -> list:
-        users = {}
+        users = []
         for org in organisations:
-            users[org] = [user['login'] for user in self.github_client_core_api.get_organization(org).get_members()]
+            [users.append(user['login']) for user in self.github_client_core_api.get_organization(org).get_members() if user['login'] not in users]
         return users
 
     @retries_github_rate_limit_exception_at_next_reset_once

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -267,7 +267,14 @@ class GithubService:
     def __get_all_users(self) -> list:
         logging.info("Getting all organization members")
         return self.github_client_core_api.get_organization(self.organisation_name).get_members() or []
-
+    
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def get_users_of_multiple_organisations(self, organisations: list) -> list:
+        combined_users = []
+        for org in organisations:   
+            combined_users = combined_users + self.github_client_core_api.get_organization(org).get_members()
+        return combined_users
+    
     @retries_github_rate_limit_exception_at_next_reset_once
     def __add_user_to_team(self, user: NamedUser, team_id: int) -> None:
         logging.info(f"Adding user {user.name} to team {team_id}")

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -272,7 +272,7 @@ class GithubService:
     def get_users_of_multiple_organisations(self, organisations: list) -> list:
         users = {}
         for org in organisations:
-            users[org] = [ user['login'] for user in self.github_client_core_api.get_organization(org).get_members() ]
+            users[org] = [user['login'] for user in self.github_client_core_api.get_organization(org).get_members()]
         return users
 
     @retries_github_rate_limit_exception_at_next_reset_once

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -272,8 +272,8 @@ class GithubService:
     def get_users_of_multiple_organisations(self, organisations: list) -> list:
         all_users = []
         for org in organisations:
-            org_users = [user["login"] for user in self.github_client_core_api.get_organization(org).get_members() if user['login'] not in all_users]
-            all_users = all_users + org_users
+            users = [user["login"] for user in self.github_client_core_api.get_organization(org).get_members() if user['login'] not in all_users]
+            all_users = all_users + users
         return all_users
 
     @retries_github_rate_limit_exception_at_next_reset_once

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -270,10 +270,10 @@ class GithubService:
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_users_of_multiple_organisations(self, organisations: list) -> list:
-        combined_users = []
+        users = {}
         for org in organisations:
-            combined_users = combined_users + self.github_client_core_api.get_organization(org).get_members()
-        return combined_users
+            users[org] = [ user['login'] for user in self.github_client_core_api.get_organization(org).get_members() ]
+        return users
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def __add_user_to_team(self, user: NamedUser, team_id: int) -> None:

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1434,24 +1434,10 @@ class TestGithubServiceGetUsersOfMultipleOrgs(unittest.TestCase):
     def test_get_users_of_multiple_organisations(self, mock_github_client_core_api):
         mock_users = [
             {
-                "login": "user1",
-                "id": 29397727,
-                "node_id": "MDQ6VXNlcjI5Mzk3NzIy",
-                "avatar_url": "https://avatars.githubusercontent.com/u/29397722?v=4",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/user1",
-                "html_url": "https://github.com/user1",
-                "followers_url": "https://api.github.com/users/user1/followers",
-                "following_url": "https://api.github.com/users/user1/following{/other_user}",
-                "gists_url": "https://api.github.com/users/user1/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/user1/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/user1/subscriptions",
-                "organizations_url": "https://api.github.com/users/user1/orgs",
-                "repos_url": "https://api.github.com/users/user1/repos",
-                "events_url": "https://api.github.com/users/user1/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/user1/received_events",
-                "type": "User",
-                "site_admin": False
+                "login": "user1"
+            },
+            {
+                "login": "user2"
             }
         ]
 
@@ -1459,7 +1445,7 @@ class TestGithubServiceGetUsersOfMultipleOrgs(unittest.TestCase):
 
         response = GithubService("", ORGANISATION_NAME).get_users_of_multiple_organisations(["org1", "org2"])
 
-        self.assertEqual(mock_users + mock_users, response)
+        self.assertEqual({ "org1": ["user1", "user2"], "org2": ["user1", "user2"] }, response)
 
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1445,7 +1445,7 @@ class TestGithubServiceGetUsersOfMultipleOrgs(unittest.TestCase):
 
         response = GithubService("", ORGANISATION_NAME).get_users_of_multiple_organisations(["org1", "org2"])
 
-        self.assertEqual({ "org1": ["user1", "user2"], "org2": ["user1", "user2"] }, response)
+        self.assertEqual({"org1": ["user1", "user2"], "org2": ["user1", "user2"]}, response)
 
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1438,7 +1438,7 @@ class TestGithubServiceGetUsersOfMultipleOrgs(unittest.TestCase):
 
         response = GithubService("", ORGANISATION_NAME).get_users_of_multiple_organisations(["org1", "org2"])
 
-        self.assertEqual({"org1": ["user1", "user2"], "org2": ["user1", "user2"]}, response)
+        self.assertEqual(["user1", "user2"], response)
 
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1428,6 +1428,41 @@ class TestGithubServiceGetMemberList(unittest.TestCase):
 
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
+@patch("github.Github.__new__")
+class TestGithubServiceGetUsersOfMultipleOrgs(unittest.TestCase):
+    def test_get_users_of_multiple_organisations(self, mock_github_client_core_api):
+        mock_users = [
+            {
+                "login": "user1",
+                "id": 29397727,
+                "node_id": "MDQ6VXNlcjI5Mzk3NzIy",
+                "avatar_url": "https://avatars.githubusercontent.com/u/29397722?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/user1",
+                "html_url": "https://github.com/user1",
+                "followers_url": "https://api.github.com/users/user1/followers",
+                "following_url": "https://api.github.com/users/user1/following{/other_user}",
+                "gists_url": "https://api.github.com/users/user1/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/user1/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/user1/subscriptions",
+                "organizations_url": "https://api.github.com/users/user1/orgs",
+                "repos_url": "https://api.github.com/users/user1/repos",
+                "events_url": "https://api.github.com/users/user1/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/user1/received_events",
+                "type": "User",
+                "site_admin": False
+            }
+        ]
+
+        mock_github_client_core_api.return_value.get_organization().get_members.return_value = mock_users
+
+        response = GithubService("", ORGANISATION_NAME).get_users_of_multiple_organisations(["org1", "org2"])
+
+        self.assertEqual(mock_users + mock_users, response)
+
+
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__")
 @patch("github.Github.__new__", new=MagicMock)
 class TestGithubServiceGetUserOrgEmailAddress(unittest.TestCase):
@@ -2135,36 +2170,6 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
         mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
         self.assertEqual(result, False)
-
-    def test_get_users_of_multiple_organisations(self, mock_github_client_rest_api, mock_github_client_core_api):
-        mock_users = [
-            {
-                "login": "user1",
-                "id": 29397727,
-                "node_id": "MDQ6VXNlcjI5Mzk3NzIy",
-                "avatar_url": "https://avatars.githubusercontent.com/u/29397722?v=4",
-                "gravatar_id": "",
-                "url": "https://api.github.com/users/user1",
-                "html_url": "https://github.com/user1",
-                "followers_url": "https://api.github.com/users/user1/followers",
-                "following_url": "https://api.github.com/users/user1/following{/other_user}",
-                "gists_url": "https://api.github.com/users/user1/gists{/gist_id}",
-                "starred_url": "https://api.github.com/users/user1/starred{/owner}{/repo}",
-                "subscriptions_url": "https://api.github.com/users/user1/subscriptions",
-                "organizations_url": "https://api.github.com/users/user1/orgs",
-                "repos_url": "https://api.github.com/users/user1/repos",
-                "events_url": "https://api.github.com/users/user1/events{/privacy}",
-                "received_events_url": "https://api.github.com/users/user1/received_events",
-                "type": "User",
-                "site_admin": False
-            }
-        ]
-
-        mock_github_client_core_api.return_value.get_organization().get_members.return_value = mock_users
-
-        response = GithubService("", ORGANISATION_NAME).get_users_of_multiple_organisations(["org1", "org2"])
-
-        self.assertEqual(mock_users + mock_users, response)
 
 
 if __name__ == "__main__":

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1432,14 +1432,7 @@ class TestGithubServiceGetMemberList(unittest.TestCase):
 @patch("github.Github.__new__")
 class TestGithubServiceGetUsersOfMultipleOrgs(unittest.TestCase):
     def test_get_users_of_multiple_organisations(self, mock_github_client_core_api):
-        mock_users = [
-            {
-                "login": "user1"
-            },
-            {
-                "login": "user2"
-            }
-        ]
+        mock_users = [{"login": "user1"}, {"login": "user2"}]
 
         mock_github_client_core_api.return_value.get_organization().get_members.return_value = mock_users
 

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2136,6 +2136,36 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         mock_reset_alerting_threshold_if_first_day_of_month.assert_called_once()
         self.assertEqual(result, False)
 
+    def test_get_users_of_multiple_organisations(self, mock_github_client_rest_api, mock_github_client_core_api):
+        mock_users = [
+            {
+                "login": "user1",
+                "id": 29397727,
+                "node_id": "MDQ6VXNlcjI5Mzk3NzIy",
+                "avatar_url": "https://avatars.githubusercontent.com/u/29397722?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/user1",
+                "html_url": "https://github.com/user1",
+                "followers_url": "https://api.github.com/users/user1/followers",
+                "following_url": "https://api.github.com/users/user1/following{/other_user}",
+                "gists_url": "https://api.github.com/users/user1/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/user1/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/user1/subscriptions",
+                "organizations_url": "https://api.github.com/users/user1/orgs",
+                "repos_url": "https://api.github.com/users/user1/repos",
+                "events_url": "https://api.github.com/users/user1/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/user1/received_events",
+                "type": "User",
+                "site_admin": False
+            }
+        ]
+
+        mock_github_client_core_api.return_value.get_organization().get_members.return_value = mock_users
+
+        response = GithubService("", ORGANISATION_NAME).get_users_of_multiple_organisations(["org1", "org2"])
+
+        self.assertEqual(mock_users + mock_users, response)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds function to Github Service which takes a list of organisations as an argument and returns a list of all users in all specified organisations.