### PR TITLE
✨ Add auto removal of inactive repositories with no commits

### DIFF
--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -194,7 +194,7 @@ class TestGithubServiceArchiveInactiveRepositories(unittest.TestCase):
                                                                                ["allow_me"])
         self.assertEqual(repo.edit.called, False)
 
-    def test_no_archive_when_repo_has_no_commits_even_if_before_cutoff(self, mock_github_client_core_api):
+    def test_no_archive_when_repo_has_no_commits_and_created_after_cutoff(self, mock_github_client_core_api):
         repo = self.__get_repository(last_active_date=self.before_cutoff, created_at_date=self.after_cutoff, has_commits=False)
         mock_github_client_core_api.return_value.get_organization().get_repos.return_value = [
             repo,
@@ -204,7 +204,7 @@ class TestGithubServiceArchiveInactiveRepositories(unittest.TestCase):
         GithubService("", ORGANISATION_NAME).archive_all_inactive_repositories(self.last_active_cutoff_date, [])
         self.assertEqual(repo.edit.called, False)
 
-    def test_archives_inactive_repositories_not_on_allow_list(self, mock_github_client_core_api):
+    def test_archives_inactive_repositories(self, mock_github_client_core_api):
         repo = self.__get_repository(self.before_cutoff, self.before_cutoff)
         repo_on_allow_list = self.__get_repository(self.before_cutoff, self.before_cutoff, repo_name="allow_this")
         mock_github_client_core_api.return_value.get_organization().get_repos.return_value = [


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- To automatically remove repositories that have been inactive and contain no commits
- ☝️ This process is currently "manual"

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Removed the logic that kept repositories with no commits around and logged them as "To manually check"
- Refactored logic to automatically remove repositories that are:
  - Created more than a year and a half ago
  - Have no commits
- Renamed a few tests

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- This change removes all manual aspects of the process
- For context, the logic (in priority order) to identify an archivable repository is `Created over a year and a half ago AND is not in allow list AND (has no commits OR latest commit is over a year and half ago)`

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
