### PR TITLE
:recycle: Exclude collaborators when identifying dormant users

### DIFF
--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -61,7 +61,7 @@ def get_usernames_from_csv_ignoring_bots_and_collaborators(bot_list: list) -> li
                 if username not in bot_list and not is_collaborator:
                     usernames.append(username)
 
-    except Exception as e:
+    except FileNotFoundError as e:
         logging.error("Error reading from file %s: %s", CSV_FILE_NAME, e)
 
     return usernames

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -46,11 +46,11 @@ class TestDormantGitHubUsers(unittest.TestCase):
                 self.allowed_bot_users)
         self.assertEqual(result, [])
 
-    def test_get_usernames_from_csv_ignoring_bots_only_bots(self):
-        mock_file_content = "ci-hmcts\ncloud-platform-dummy-user\n"
-        with patch("builtins.open", mock_open(read_data=mock_file_content)):
-            result = get_usernames_from_csv_ignoring_bots_and_collaborators(
-                self.allowed_bot_users)
+    @patch("builtins.open", new_callable=mock_open, read_data="created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,bot2,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,bot1,user,31.121.104.4,true,false")
+    def test_get_usernames_from_csv_ignoring_bots_only_bots(self, mock_file_content):
+        bot_list = ['bot1', 'bot2']
+        result = get_usernames_from_csv_ignoring_bots_and_collaborators(
+            bot_list=bot_list)
         self.assertEqual(result, [])
 
     @patch("builtins.open", new_callable=mock_open, read_data="created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,joebloggs,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,jamesoutsidecollaborator,user,31.121.104.4,true,true")

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -46,18 +46,20 @@ class TestDormantGitHubUsers(unittest.TestCase):
                 self.allowed_bot_users)
         self.assertEqual(result, [])
 
-    @patch("builtins.open", new_callable=mock_open, read_data="created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,bot2,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,bot1,user,31.121.104.4,true,false")
-    def test_get_usernames_from_csv_ignoring_bots_only_bots(self, mock_file_content):
+    def test_get_usernames_from_csv_ignoring_bots_only_bots(self):
+        mock_file_content = "created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,bot2,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,bot1,user,31.121.104.4,true,false"
         bot_list = ['bot1', 'bot2']
-        result = get_usernames_from_csv_ignoring_bots_and_collaborators(
-            bot_list=bot_list)
+        with patch("builtins.open", mock_open(read_data=mock_file_content)):
+            result = get_usernames_from_csv_ignoring_bots_and_collaborators(
+                bot_list=bot_list)
         self.assertEqual(result, [])
 
-    @patch("builtins.open", new_callable=mock_open, read_data="created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,joebloggs,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,jamesoutsidecollaborator,user,31.121.104.4,true,true")
-    def test_get_usernames_from_csv_ignoring_bots_and_collaborators(self, mock_file):
+    def test_get_usernames_from_csv_ignoring_bots_and_collaborators(self):
+        mock_file_content = "created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,joebloggs,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,jamesoutsidecollaborator,user,31.121.104.4,true,true"
         bot_list = ['bot1', 'bot2']
-        usernames = get_usernames_from_csv_ignoring_bots_and_collaborators(
-            bot_list)
+        with patch("builtins.open", mock_open(read_data=mock_file_content)):
+            usernames = get_usernames_from_csv_ignoring_bots_and_collaborators(
+                bot_list)
         self.assertEqual(usernames, ['joebloggs'])
 
     @patch('boto3.client')


### PR DESCRIPTION
Previously, the `get_usernames_from_csv_ignoring_bots` function returned a list of usernames from a CSV file that weren't identified as bot accounts. This commit makes two significant changes:

1) The function now also excludes outside collaborators. It has been renamed to `get_usernames_from_csv_ignoring_bots_and_collaborators` to reflect this change.

2) The parsing of CSV data has been updated from using a standard reader to a Dictionary Reader for improved readability. Now, instead of indexing column values by their order in the row, they can be accessed via their column header names.

Unit tests have also been updated and expanded to verify these changes.