### PR TITLE
:lock: Add write permissions to GitHub Action workflow

### DIFF
--- a/.github/workflows/exprimental-identify-dormant-github-users.yml
+++ b/.github/workflows/exprimental-identify-dormant-github-users.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   identify_dormant_github_users:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS credentials

--- a/.github/workflows/exprimental-identify-dormant-github-users.yml
+++ b/.github/workflows/exprimental-identify-dormant-github-users.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS credentials


### PR DESCRIPTION
This update adds `write` permissions for both `id-token` and `contents` in the GitHub Actions workflow file `exprimental-identify-dormant-github-users.yml`. With this change, the job `identify_dormant_github_users` now has write access that may be necessary for its tasks. Please review and ensure this aligns with our access control policies.