### PR TITLE
:arrow_down: Downgrade Python version for 'Identify Dormant GitHub Us…

### DIFF
--- a/.github/workflows/exprimental-identify-dormant-github-users.yml
+++ b/.github/workflows/exprimental-identify-dormant-github-users.yml
@@ -19,7 +19,7 @@ jobs:
           aws-region: eu-west-2
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: "pipenv"
       - name: Install Pipenv
         run: |


### PR DESCRIPTION
I jumped the gun on the python version - we are actually using 3.11
