### PR TITLE
Add repository for ops-engineering DNS spike

### DIFF
--- a/terraform/github/repositories/ministryofjustice/operations-engineering-dns-spike
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-dns-spike
@@ -1,0 +1,12 @@
+module "operations-engineering-dns-spike" {
+  source  = "ministryofjustice/repository/github"
+  version = "0.0.7"
+
+  name        = "operations-engineering-dns-spike"
+  description = "DNS spike for the operations engineering team"
+  topics      = ["operations-engineering", "dns", "spike"]
+
+  team_access = {
+    admin = [var.operations_engineering_team_id]
+  }
+}


### PR DESCRIPTION
Add a new Terraform module to define the repository 'operations-engineering-dns-spike' within the Ministry of Justice GitHub organization. This module includes the necessary configuration for the repository, such as its name, description, topics, and team access permissions.