### PR TITLE
:sparkles: Create IAM policy and role for OctoDNS in Route53

### DIFF
--- a/terraform/dsd/iam/github_oidc.tf
+++ b/terraform/dsd/iam/github_oidc.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy_document" {
     condition {
       test     = "StringLike"
       variable = "${local.oidc_provider}:sub"
-      values   = ["repo:ministryofjustice/operations-engineering:*"]
+      values   = ["repo:ministryofjustice/operations-engineering:*", "repo:ministryofjustice/operations-engineering-dns-spike:*"]
     }
 
     condition {

--- a/terraform/dsd/iam/octodns_role.tf
+++ b/terraform/dsd/iam/octodns_role.tf
@@ -1,0 +1,46 @@
+
+resource "aws_iam_policy" "dns_change_records_policy" {
+  name        = "Route53ChangeRecordsPolicy"
+  description = "A policy that allows modification of the Route53 record sets for the dns-test.service.justice.gov.uk hosted zone."
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "arn:aws:route53:::hostedzone/test-dns.service.justice.gov.uk"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetHostedZone",
+        "route53:ListHostedZones"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "octodns_role" {
+  name = "octodns_role"
+
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+  role       = aws_iam_role.octodns_role.name
+  policy_arn = aws_iam_policy.dns_change_records_policy.arn
+}
+
+resource "github_actions_secret" "octodns_role" {
+  repository      = "operations-engineering-dns-spike"
+  secret_name     = "OCTODNS_AWS_ROLE_ARN"
+  plaintext_value = aws_iam_role.octodns_role.arn
+}

--- a/terraform/dsd/iam/octodns_role.tf
+++ b/terraform/dsd/iam/octodns_role.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "octodns_role" {
   assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy_document.json
 }
 
-resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "octo_dns_role_policy_attachment" {
   role       = aws_iam_role.octodns_role.name
   policy_arn = aws_iam_policy.dns_change_records_policy.arn
 }


### PR DESCRIPTION
:eyes: Purpose
---

• This PR introduces an IAM policy to manage Route53 records. It allows adding, changing, and deleting Route53 records for the test-dns.service.justice.gov.uk hosted zone.

:recycle: What's Changed
---

• Added a new IAM policy route53_policy in the github_oidc.tf Terraform file. 

• Attached the new policy to the octodns_role IAM role.
