### PR TITLE
✨ Add KPI tracking for number of repositories with `configure-standards` label

### DIFF
--- a/.github/workflows/job-apply-standards.yml
+++ b/.github/workflows/job-apply-standards.yml
@@ -21,6 +21,8 @@ jobs:
       - run: pipenv run python3 -m bin.configure_standards
         env:
           ADMIN_GITHUB_TOKEN: ${{ secrets.GH_BOT_PAT_TOKEN }}
+          KPI_DASHBOARD_URL: ${{ secrets.KPI_DASHBOARD_POC_URL }}
+          KPI_DASHBOARD_API_KEY: ${{ secrets.KPI_DASHBOARD_POC_API_KEY }}
       - name: Report failure to Slack
         if: always()
         uses: ravsamhq/notify-slack-action@v2

--- a/bin/configure_standards.py
+++ b/bin/configure_standards.py
@@ -1,5 +1,8 @@
+import logging
 import os
+
 from services.github_service import GithubService
+from services.kpi_service import KpiService
 
 
 def get_environment_variables() -> str:
@@ -22,6 +25,12 @@ def main():
 
     current_repos = [repo_dict['repo']['name']
                      for repo_dict in data['search']['repos']]
+
+    try:
+        KpiService(os.getenv("KPI_DASHBOARD_URL"), os.getenv("KPI_DASHBOARD_API_KEY")).track_number_of_repositories_with_standards_label(len(current_repos))
+    except Exception as e:
+        logging.info("Issue when trying to track number of repositories with standards label...")
+        logging.error(e)
 
     for repos in current_repos:
         github.set_standards(repository_name=repos)

--- a/services/kpi_service.py
+++ b/services/kpi_service.py
@@ -1,0 +1,21 @@
+import logging
+from typing import Dict
+
+import requests
+from requests import Response
+
+logger = logging.getLogger("myapp")
+logging.basicConfig()
+
+
+class KpiService:
+    def __init__(self, base_url: str, api_key: str):
+        self.__base_url = base_url
+        self.__request_headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+        self.__request_timeout = 10
+
+    def __post(self, endpoint: str, data: Dict) -> Response:
+        return requests.post(url=f"{self.__base_url}{endpoint}", headers=self.__request_headers, timeout=self.__request_timeout, json=data)
+
+    def track_number_of_repositories_with_standards_label(self, count: int):
+        self.__post("/api/indicator/add", {"indicator": "REPOSITORIES_WITH_STANDARDS_LABEL", "count": count})


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- In relation to [#4420](https://github.com/ministryofjustice/operations-engineering/issues/4420)
- To track low risk, simple live metric to prove the concept of a KPI Dashboard

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added a KPIService for easily allowing scripts to track metrics
- Added a metric tracker to the configure standards job

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- Wrapped all additional tracking code in a try/except block - so any errors won't affect normal processing

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
