### PR TITLE
Add HmppsDigitalServiceAccount to dormant users allow list

### DIFF
--- a/bin/dormant_users.py
+++ b/bin/dormant_users.py
@@ -34,6 +34,7 @@ MINISTRY_OF_JUSTICE_ALLOW_LIST = [
     "mojanalytics",
     "laaserviceaccount",
     "analytical-platform-bot",
+    "HmppsDigitalServiceAccount",
 ]
 
 MOJ_ANALYTICAL_SERVICES_ALLOW_LIST = [


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

• PR adds HmppsDigitalServiceAccount to the dormant users allow list. This account is expected to be low activity which could make the account look dormant and removal of the user could break critical services.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• User `HmppsDigitalServiceAccount` added to allow list