### PR TITLE
Add HmppsDigitalServiceAccount to dormant users allow list

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -307,8 +307,8 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [FORMAT]

--- a/bin/dormant_users.py
+++ b/bin/dormant_users.py
@@ -34,7 +34,7 @@ MINISTRY_OF_JUSTICE_ALLOW_LIST = [
     "mojanalytics",
     "laaserviceaccount",
     "analytical-platform-bot",
-    "HmppsDigitalServiceAccount",
+    "hmppsdigitalserviceaccount",
 ]
 
 MOJ_ANALYTICAL_SERVICES_ALLOW_LIST = [

--- a/bin/dormant_users.py
+++ b/bin/dormant_users.py
@@ -34,6 +34,7 @@ MINISTRY_OF_JUSTICE_ALLOW_LIST = [
     "mojanalytics",
     "laaserviceaccount",
     "analytical-platform-bot",
+    "HmppsDigitalServiceAccount",
 ]
 
 MOJ_ANALYTICAL_SERVICES_ALLOW_LIST = [


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

• PR adds `HmppsDigitalServiceAccount` to the dormant users allow list. This account is expected to be low activity which could make the account look dormant and removal of the user could break critical services.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• User `hmppsdigitalserviceaccount` added to allow list
• Update `overgeneral-exceptions` value to fix linting failure