### PR TITLE
:recycle: Ensure identify_dormant_github_users fails with exception

### DIFF
--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -106,12 +106,7 @@ def message_to_slack_channel(list_of_dormant_users: list) -> str:
 
 
 def identify_dormant_github_users():
-    env = None
-    try:
-        env = EnvironmentVariables(["GH_ADMIN_TOKEN", "ADMIN_SLACK_TOKEN"])
-    except EnvironmentError as e:
-        logger.critical("Error: %s", e)
-        return
+    env = EnvironmentVariables(["GH_ADMIN_TOKEN", "ADMIN_SLACK_TOKEN"])
 
     dormant_users_from_csv = get_dormant_users_from_github_csv(
         GithubService(env.get('GH_ADMIN_TOKEN'), ORGANISATION)


### PR DESCRIPTION
As this bin file is most likely to be run inside a GitHub Action it needs to exit with non-0. The best way to do this is to let the exception bubble up to the runner and exit forcefully.