### PR TITLE
:sparkles: Add operations-engineering-terraform-dns-poc repository

### DIFF
--- a/terraform/github/repositories/ministryofjustice/operations-engineering-octodns-poc.tf
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-octodns-poc.tf
@@ -1,0 +1,12 @@
+module "operations-engineering-octodns-poc" {
+  source  = "ministryofjustice/repository/github"
+  version = "1.0.1"
+
+  name        = "operations-engineering-octodns-poc"
+  description = "This repository will be used to prove the concept of managing DNS records using OctoDNS."
+  topics      = ["operations-engineering", "dns", "spike"]
+
+  team_access = {
+    admin = [var.operations_engineering_team_id]
+  }
+}

--- a/terraform/github/repositories/ministryofjustice/operations-engineering-terraform-dns-poc
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-terraform-dns-poc
@@ -1,0 +1,12 @@
+module "operations-engineering-terraform-dns-poc" {
+  source  = "ministryofjustice/repository/github"
+  version = "1.0.1"
+
+  name        = "operations-engineering-terraform-dns-poc"
+  description = "This repository will be used to prove the concept of managing DNS records using Terraform."
+  topics      = ["operations-engineering", "dns", "spike"]
+
+  team_access = {
+    admin = [var.operations_engineering_team_id]
+  }
+}


### PR DESCRIPTION
This repository will house code and configuration to prove Terraform is or isn't appropriate to manage our dns estate
