### PR TITLE
:recycle: Exclusively Using the Main Branch for Pipeline Checks

### DIFF
--- a/services/circleci_service.py
+++ b/services/circleci_service.py
@@ -12,7 +12,7 @@ class CircleciService:
         }
 
     def get_circleci_pipelines_for_repository(self, repo):
-        url = self.base_url + f"project/github/{self.github_org}/{repo}/pipeline"
+        url = self.base_url + f"project/github/{self.github_org}/{repo}/pipeline?branch=main"
         response = requests.get(url, headers=self.headers, timeout=60)
         if response.status_code != 200:
             print(f"Error getting pipelines for {repo}: {response.text}")

--- a/test/test_services/test_circleci_service.py
+++ b/test/test_services/test_circleci_service.py
@@ -24,7 +24,7 @@ class TestCircleciService(unittest.TestCase):
         self.assertEqual(pipelines[0]["id"], "pipeline1")
         self.assertEqual(pipelines[1]["id"], "pipeline2")
 
-        url = f"https://circleci.com/api/v2/project/github/{self.github_org}/{repo}/pipeline"
+        url = f"https://circleci.com/api/v2/project/github/{self.github_org}/{repo}/pipeline?branch=main"
         mock_get.assert_called_once_with(url, headers=self.service.headers, timeout=60)
 
     def test_get_circleci_pipelines_for_repository_failure(self, mock_get):


### PR DESCRIPTION
This change aims to fix inaccurate unused context being reported, by focusing only on the main branch of a repository.

<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

To improve the accuracy of the list of unused contexts that is being generated.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

Small URL change to only gather pipelines from the main branch of a project.

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

No notes.

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [x] I have checked that all new dependencies are up to date and necessary.
