### PR TITLE
Update CODEOWNERS to allow direct merges for support stats

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 *   @ministryofjustice/operations-engineering
+
+/data/* @andyrogers1973


### PR DESCRIPTION
- Added Andy as sole owner of /data/ directory
- Enables daily support stats to be merged without additional approval
- Streamlines process for updating routine operational data
- Only affects /data/ directory; other repo protections remain intact