### PR TITLE
🔧 Create Operations Engineering Support Team + Auto-approve Support Stats PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *   @ministryofjustice/operations-engineering
 
-/data/* @andyrogers1973
+/data/* @ministryofjustice/operations-engineering-support

--- a/.github/workflows/cicd-terraform-github-teams.yml
+++ b/.github/workflows/cicd-terraform-github-teams.yml
@@ -1,0 +1,91 @@
+name: "♻️ Terraform GitHub Teams"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "terraform/github/teams/**"
+    branches:
+      - main
+  push:
+    paths:
+      - "terraform/github/teams/**"
+    branches: ["main"]
+
+env:
+  TERRAFORM_VERSION: "1.6.6"
+  TF_VAR_github_token: ${{ secrets.OPS_ENG_GENERAL_ADMIN_BOT_PAT }}
+
+jobs:
+  terraform:
+    name: "Terraform GitHub Teams"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    defaults:
+      run:
+        working-directory: "terraform/github/teams"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.TERRAFORM_GITHUB_TEAMS_S3_ROLE_ARN_PROD}}
+          aws-region: eu-west-2
+
+      - name: Post Link to Apply Pipeline
+        if: github.ref == 'refs/heads/main'
+        uses: mshick/add-pr-comment@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: "github-actions[bot]"
+          message: |
+            Your PR is applying here: https://github.com/ministryofjustice/operations-engineering/actions/workflows/cicd-terraform-github-teams.yml?query=event%3Apush+branch%3Amain
+
+      - name: Terraform Format Check
+        id: fmt-check
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        id: init
+        run: terraform init -input=false -no-color
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -input=false -no-color
+
+      - name: Delete Old Comments
+        uses: maheshrayas/action-pr-comment-delete@v3.0
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          org: ministryofjustice
+          repo: operations-engineering
+          user: "github-actions[bot]"
+          issue: "${{github.event.number}}"
+
+      - name: Post Plan to GitHub PR
+        if: github.ref != 'refs/heads/main'
+        uses: mshick/add-pr-comment@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: "github-actions[bot]"
+          message: |
+            ## Terraform GitHub Teams plan
+            ```
+            ${{ steps.plan.outputs.stdout || steps.plan.outputs.stderr }}
+            ```
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main'
+        id: apply
+        run: terraform apply -input=false -no-color -auto-approve

--- a/.github/workflows/experiment-auto-approve-support.yml
+++ b/.github/workflows/experiment-auto-approve-support.yml
@@ -1,0 +1,25 @@
+name: 🧪 Auto-merge Support Stats
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "data/**"
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check team membership and auto-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPS_ENG_GENERAL_ADMIN_BOT_PAT }}
+          ORGANISATION: ministryofjustice
+          TEAM: operations-engineering-support
+        run: |
+          # Check if the PR author is in the operations-engineering-support team
+          if gh api orgs/$ORGANISATION/teams/$TEAM/memberships/${{ github.event.pull_request.user.login }} --silent; then
+            echo "User is in the operations-engineering-support team. Proceeding with auto-merge."
+            gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"
+          else
+            echo "User is not in the operations-engineering-support team. Skipping auto-merge."
+          fi

--- a/terraform/github/teams/main.tf
+++ b/terraform/github/teams/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "cloud-platform-fad89ef06d68fdbc1928cb37acd8fc9f"
+    dynamodb_table = "cp-1aaae79e1c9a29a8"
+    encrypt        = true
+    key            = "terraform/github-teams/operations-engineering-prod/terraform.tfstate"
+    region         = "eu-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.31.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+  required_version = "~> 1.6"
+}
+
+provider "github" {
+  token = var.github_token
+  owner = "ministryofjustice"
+}
+
+provider "github" {
+  alias = "ministryofjustice-test"
+  token = var.github_token
+  owner = "ministryofjustice-test"
+}

--- a/terraform/github/teams/operations_engineering_support.tf
+++ b/terraform/github/teams/operations_engineering_support.tf
@@ -1,0 +1,12 @@
+resource "github_team" "ops_eng_support" {
+  name        = "operations-engineering-support"
+  description = "Team for support engineers"
+  privacy     = "closed"
+}
+
+resource "github_team_membership" "ops_eng_support_memberships" {
+  for_each = toset(var.ops_eng_support_members)
+  team_id  = github_team.ops_eng_support.id
+  username = each.value
+  role     = "member"
+}

--- a/terraform/github/teams/variables.tf
+++ b/terraform/github/teams/variables.tf
@@ -1,0 +1,15 @@
+variable "github_token" {
+  type        = string
+  description = "Required by the GitHub Terraform provider"
+  default     = ""
+}
+
+
+variable "ops_eng_support_members" {
+  description = "List of GitHub usernames for operations-engineering-support team members"
+  type        = list(string)
+  default = [
+    "andyrogers1973",
+  ]
+}
+


### PR DESCRIPTION
## 👀 Purpose

- This PR creates a new Operations Engineering team called `operations-engineering-support`.
- When a member of the new team PRs a change to the `data` directory, they won't need approval from the `operations-engineering` team.

## ♻️ What's changed

- Implementation of a new Terraform-managed pipeline that creates and manages GitHub teams. This setup:
  - Creates a new team called `operations-engineering-support`.
  - May evolve to include declaring members of the `operations-engineering` team.
- A change to the CODEOWNERS file, assigning ownership of the `data` directory to the new team.
- A new GitHub Actions workflow to auto-approve PRs from the support team.

## 📝 Notes

- The auto-approve GitHub Action is designed to auto-merge PRs only when they exclusively affect the `data/` directory. If the PR includes changes to other directories, it won't qualify for automatic merging.
- This setup provides enhanced security through:
  - Limiting streamlined processes to a specific directory and team.
  - Maintaining an audit trail of team membership changes through version control.
- Team members must be added to the new `operations-engineering-support` team to benefit from the new permissions.
- Adding or removing team members will be done through Terraform code changes and pull requests, ensuring oversight and traceability.

## 🔄 Next Steps

- Add appropriate team members to the `operations-engineering-support` team.
- Monitor the effectiveness of this new workflow and adjust as necessary.