### PR TITLE
✨ Add Role to Assume Cloud Platform Route53 Read Role

### DIFF
--- a/terraform/dsd/iam/cloud_platform_route53_read_role.tf
+++ b/terraform/dsd/iam/cloud_platform_route53_read_role.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_role" "assume_cloud_platform_route53_read_role" {
+  name               = "assume_cloud_platform_route53_read_role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy_document.json
+}
+
+resource "github_actions_secret" "assume_cloud_platform_route53_read_role_arn" {
+  repository      = "operations-engineering"
+  secret_name     = "ASSUME_CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN"
+  plaintext_value = aws_iam_role.assume_cloud_platform_route53_read_role.arn
+}


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- To enable Cloud Platform to create a role to be assumed by this role 🎩 

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added the `assume_cloud_platform_route53_read_role` 

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- The role has no policies at the moment, this will generate an ARN so Cloud Platform can construct a policy to allow this role to assume their Route53 Read Role. Once their role has been created in the Cloud Platform account, we will update the policy for this role to be able to assume their role <insert confused math lady meme / crazyblob slack emoji>

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
