### PR TITLE
:sparkles: Add new role for accessing AWS Secret Manager Secrets

### DIFF
--- a/terraform/dsd/iam/operations_engineering_test_secrets_manager_role.tf
+++ b/terraform/dsd/iam/operations_engineering_test_secrets_manager_role.tf
@@ -1,0 +1,31 @@
+resource "aws_iam_policy" "secrets_manager_policy" {
+  name        = "operations_engineering_test_secrets_manager_policy"
+  description = "Policy to allow access for the operations-engineering-test-secrets-manager repository to appropriate secrets in AWS Secrets Manager."
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Action = [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_iam_role" "secrets_manager_role" {
+  name               = "operations_engineering_test_secrets_manager_role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "secrets_manager_attachment" {
+  role       = aws_iam_role.secrets_manager_role.name
+  policy_arn = aws_iam_policy.secrets_manager_policy.arn
+}
+
+resource "github_actions_secret" "secrets_manager_role_arn" {
+  repository      = "operations-engineering"
+  secret_name     = "AWS_SECRETS_MANAGER_ROLE_ARN"
+  plaintext_value = aws_iam_role.secrets_manager_role.arn
+}


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

To create a new role to enable access to the secrets in the AWS Secrets Manager. Currently there's only a single secret there that has been manually created. Principle of Least Privilege practices can be discussed and implemented at a later date, the wildcard resource allocation is just for PoC purposes.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- New role created to access AWS Secrets Manager secrets.
- Role ARN attached to operations-engineering repository as a secret.

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes
•

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
