### PR TITLE
:sparkles: Autogenerate operations-engineering-test terraform configuration

### DIFF
--- a/terraform/auth0/operations-engineering-test/auth0_import.tf
+++ b/terraform/auth0/operations-engineering-test/auth0_import.tf
@@ -1,0 +1,30 @@
+import {
+  id = "38c317cd-592f-4110-81b1-8c10ccdabbce"
+  to = auth0_attack_protection.attack_protection
+}
+
+import {
+  id = "qkvVnu0b4pXd6FdEbjm073w4MchhpOoB"
+  to = auth0_client.default_app
+}
+
+import {
+  id = "xI46sB1af7TKeycQ3xfTA2qIxeLiX2R8"
+  to = auth0_client.terraform_provider_auth0
+}
+
+import {
+  id = "con_yyrB18AQbSUcMLTm"
+  to = auth0_connection.google_oauth2
+}
+
+import {
+  id = "65942c8d2208302c27c666f4"
+  to = auth0_resource_server.auth0_management_api
+}
+
+import {
+  id = "356f7392-d013-479e-a184-4dd1237568c8"
+  to = auth0_tenant.tenant
+}
+

--- a/terraform/auth0/operations-engineering-test/clients.tf
+++ b/terraform/auth0/operations-engineering-test/clients.tf
@@ -1,0 +1,180 @@
+resource "auth0_client" "terraform_provider_auth0" {
+  allowed_clients                       = []
+  allowed_logout_urls                   = []
+  allowed_origins                       = []
+  app_type                              = "non_interactive"
+  callbacks                             = []
+  client_aliases                        = []
+  client_metadata                       = {}
+  cross_origin_auth                     = false
+  cross_origin_loc                      = null
+  custom_login_page                     = null
+  custom_login_page_on                  = true
+  description                           = null
+  encryption_key                        = {}
+  form_template                         = null
+  grant_types                           = ["client_credentials"]
+  initiate_login_uri                    = null
+  is_first_party                        = true
+  is_token_endpoint_ip_header_trusted   = false
+  logo_uri                              = null
+  name                                  = "Terraform Provider Auth0"
+  oidc_backchannel_logout_urls          = []
+  oidc_conformant                       = true
+  organization_require_behavior         = null
+  organization_usage                    = null
+  require_pushed_authorization_requests = false
+  sso                                   = false
+  sso_disabled                          = false
+  web_origins                           = []
+  jwt_configuration {
+    alg                 = "RS256"
+    lifetime_in_seconds = 36000
+    scopes              = {}
+    secret_encoded      = false
+  }
+  refresh_token {
+    expiration_type              = "non-expiring"
+    idle_token_lifetime          = 2592000
+    infinite_idle_token_lifetime = true
+    infinite_token_lifetime      = true
+    leeway                       = 0
+    rotation_type                = "non-rotating"
+    token_lifetime               = 31557600
+  }
+}
+
+resource "auth0_connection" "google_oauth2" {
+  display_name         = null
+  is_domain_connection = false
+  metadata             = {}
+  name                 = "google-oauth2"
+  realms               = ["google-oauth2"]
+  show_as_button       = null
+  strategy             = "google-oauth2"
+  options {
+    adfs_server                            = null
+    allowed_audiences                      = []
+    api_enable_users                       = false
+    app_id                                 = null
+    auth_params                            = {}
+    authorization_endpoint                 = null
+    brute_force_protection                 = false
+    client_id                              = null
+    client_secret                          = null # sensitive
+    community_base_url                     = null
+    configuration                          = null # sensitive
+    custom_scripts                         = {}
+    debug                                  = false
+    digest_algorithm                       = null
+    disable_cache                          = false
+    disable_self_service_change_password   = false
+    disable_sign_out                       = false
+    disable_signup                         = false
+    discovery_url                          = null
+    domain                                 = null
+    domain_aliases                         = []
+    enable_script_context                  = false
+    enabled_database_customization         = false
+    entity_id                              = null
+    fed_metadata_xml                       = null
+    fields_map                             = null
+    forward_request_info                   = false
+    from                                   = null
+    gateway_url                            = null
+    icon_url                               = null
+    identity_api                           = null
+    import_mode                            = false
+    ips                                    = []
+    issuer                                 = null
+    jwks_uri                               = null
+    key_id                                 = null
+    map_user_id_to_id                      = false
+    max_groups_to_retrieve                 = null
+    messaging_service_sid                  = null
+    metadata_url                           = null
+    metadata_xml                           = null
+    name                                   = null
+    non_persistent_attrs                   = []
+    password_policy                        = null
+    ping_federate_base_url                 = null
+    pkce_enabled                           = false
+    protocol_binding                       = null
+    provider                               = null
+    request_template                       = null
+    requires_username                      = false
+    scopes                                 = ["email", "profile"]
+    scripts                                = {}
+    set_user_root_attributes               = null
+    should_trust_email_verified_connection = null
+    sign_in_endpoint                       = null
+    sign_out_endpoint                      = null
+    sign_saml_request                      = false
+    signature_algorithm                    = null
+    signing_cert                           = null
+    strategy_version                       = 0
+    subject                                = null
+    syntax                                 = null
+    team_id                                = null
+    template                               = null
+    tenant_domain                          = null
+    token_endpoint                         = null
+    twilio_sid                             = null
+    twilio_token                           = null # sensitive
+    type                                   = null
+    upstream_params                        = null
+    use_cert_auth                          = false
+    use_kerberos                           = false
+    use_wsfed                              = false
+    user_id_attribute                      = null
+    userinfo_endpoint                      = null
+    waad_common_endpoint                   = false
+    waad_protocol                          = null
+  }
+}
+
+resource "auth0_client" "default_app" {
+  allowed_clients                       = []
+  allowed_logout_urls                   = []
+  allowed_origins                       = []
+  app_type                              = null
+  callbacks                             = []
+  client_aliases                        = []
+  client_metadata                       = {}
+  cross_origin_auth                     = false
+  cross_origin_loc                      = null
+  custom_login_page                     = null
+  custom_login_page_on                  = true
+  description                           = null
+  encryption_key                        = {}
+  form_template                         = null
+  grant_types                           = ["authorization_code", "implicit", "refresh_token", "client_credentials"]
+  initiate_login_uri                    = null
+  is_first_party                        = true
+  is_token_endpoint_ip_header_trusted   = false
+  logo_uri                              = null
+  name                                  = "Default App"
+  oidc_backchannel_logout_urls          = []
+  oidc_conformant                       = true
+  organization_require_behavior         = null
+  organization_usage                    = null
+  require_pushed_authorization_requests = false
+  sso                                   = false
+  sso_disabled                          = false
+  web_origins                           = []
+  jwt_configuration {
+    alg                 = "RS256"
+    lifetime_in_seconds = 36000
+    scopes              = {}
+    secret_encoded      = false
+  }
+  refresh_token {
+    expiration_type              = "non-expiring"
+    idle_token_lifetime          = 1296000
+    infinite_idle_token_lifetime = true
+    infinite_token_lifetime      = true
+    leeway                       = 0
+    rotation_type                = "non-rotating"
+    token_lifetime               = 2592000
+  }
+}

--- a/terraform/auth0/operations-engineering-test/tenant.tf
+++ b/terraform/auth0/operations-engineering-test/tenant.tf
@@ -1,7 +1,93 @@
-resource "auth0_tenant" "operations-engineering-test" {
-  friendly_name         = "Operations Engineering Test"
-  idle_session_lifetime = 72
-  session_lifetime      = 168
-  support_email         = "operations-engineering@digital.justice.gov.uk"
-  support_url           = "https://github.com/ministryofjustice/operations-engineering/issues/new/choose"
+resource "auth0_tenant" "tenant" {
+  allow_organization_name_in_authentication_api = false
+  allowed_logout_urls                           = []
+  customize_mfa_in_postlogin_action             = false
+  default_audience                              = null
+  default_directory                             = null
+  default_redirection_uri                       = null
+  enabled_locales                               = ["en"]
+  friendly_name                                 = null
+  idle_session_lifetime                         = 72
+  picture_url                                   = null
+  sandbox_version                               = "18"
+  session_lifetime                              = 168
+  support_email                                 = null
+  support_url                                   = null
+  flags {
+    allow_legacy_delegation_grant_types    = false
+    allow_legacy_ro_grant_types            = false
+    allow_legacy_tokeninfo_endpoint        = false
+    dashboard_insights_view                = false
+    dashboard_log_streams_next             = false
+    disable_clickjack_protection_headers   = false
+    disable_fields_map_fix                 = false
+    disable_management_api_sms_obfuscation = false
+    enable_adfs_waad_email_verification    = false
+    enable_apis_section                    = false
+    enable_client_connections              = false
+    enable_custom_domain_in_emails         = false
+    enable_dynamic_client_registration     = false
+    enable_idtoken_api2                    = false
+    enable_legacy_logs_search_v2           = false
+    enable_legacy_profile                  = false
+    enable_pipeline2                       = false
+    enable_public_signup_user_exists_error = false
+    mfa_show_factor_list_on_enrollment     = false
+    no_disclose_enterprise_connections     = false
+    require_pushed_authorization_requests  = false
+    revoke_refresh_token_grant             = false
+    use_scope_descriptions_for_consent     = false
+  }
+  session_cookie {
+    mode = null
+  }
+  sessions {
+    oidc_logout_prompt_enabled = false
+  }
+}
+
+resource "auth0_resource_server" "auth0_management_api" {
+  allow_offline_access                            = false
+  enforce_policies                                = null
+  identifier                                      = "https://operations-engineering-test.uk.auth0.com/api/v2/"
+  name                                            = "Auth0 Management API"
+  signing_alg                                     = "RS256"
+  signing_secret                                  = null
+  skip_consent_for_verifiable_first_party_clients = false
+  token_dialect                                   = null
+  token_lifetime                                  = 86400
+  token_lifetime_for_web                          = 7200
+  verification_location                           = null
+}
+
+resource "auth0_attack_protection" "attack_protection" {
+  breached_password_detection {
+    admin_notification_frequency = []
+    enabled                      = false
+    method                       = "standard"
+    shields                      = []
+    pre_user_registration {
+      shields = []
+    }
+  }
+  brute_force_protection {
+    allowlist    = []
+    enabled      = true
+    max_attempts = 10
+    mode         = "count_per_identifier_and_ip"
+    shields      = ["block", "user_notification"]
+  }
+  suspicious_ip_throttling {
+    allowlist = []
+    enabled   = true
+    shields   = ["admin_notification", "block"]
+    pre_login {
+      max_attempts = 100
+      rate         = 864000
+    }
+    pre_user_registration {
+      max_attempts = 50
+      rate         = 1200
+    }
+  }
 }


### PR DESCRIPTION
This commit creates infrastructure as code for all items we want to manage in Terraform. I used the auto-generation technique outlined here and hope that after importing, I can remove the auth0_import.tf file.
