### PR TITLE
Add New Repository Secret to operations-engineering-test-secrets-manager

### DIFF
--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -33,7 +33,20 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS credentials for accessing AWS Secrets Manager in the DSD account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_SECRETS_MANAGER_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Save AWS credentials for accessing AWS Secrets Manager in the DSD account to a new profile
+        run: |
+          aws configure set region ${{ env.AWS_REGION }} --profile dsd_secret_manager_access_profile
+          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile dsd_secret_manager_access_profile
+          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile dsd_secret_manager_access_profile
+          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile dsd_secret_manager_access_profile
+
+      - name: Configure AWS credentials to access state bucket in Cloud Platform account
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.TERRAFORM_GITHUB_REPOS_S3_ROLE_ARN_PROD}}

--- a/terraform/github/repositories/main.tf
+++ b/terraform/github/repositories/main.tf
@@ -25,8 +25,14 @@ provider "github" {
   owner = "ministryofjustice"
 }
 
+
 provider "github" {
   alias = "ministryofjustice-test"
   token = var.github_token
   owner = "ministryofjustice-test"
+}
+
+provider "aws" {
+  profile = "dsd_secret_manager_access_profile"
+  region  = "eu-west-2"
 }

--- a/terraform/github/repositories/ministryofjustice/operations-engineering-test-secrets-manager.tf
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-test-secrets-manager.tf
@@ -10,3 +10,17 @@ module "operations-engineering-test-secrets-manager" {
     admin = [var.operations_engineering_team_id]
   }
 }
+
+data "aws_secretsmanager_secret" "example_secret" {
+  name = "EXAMPLE_SECRET"
+}
+
+data "aws_secretsmanager_secret_version" "example_secret_version" {
+  secret_id = data.aws_secretsmanager_secret.example_secret.id
+}
+
+resource "github_actions_secret" "example_secret" {
+  repository      = "operations-engineering-test-secrets-manager"
+  secret_name     = "EXAMPLE_SECRET"
+  plaintext_value = jsondecode(data.aws_secretsmanager_secret_version.example_secret_version.secret_string)["EXAMPLE_SECRET"]
+}


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

To associate an already existing secret in the AWS Secret Manager (DSD account) to the operations-engineering-test-secrets-manager repository.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- New secret EXAMPLE_SECRET manually added to the AWS Secrets Manager in the DSD account
- EXAMPLE_SECRET defined and added to the operations-engineering-test-secrets-manager repository.
- New role exported to a profile in the workflow, and included in the AWS provider configuration.

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes
•

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [x] I have checked that all new dependencies are up to date and necessary.
