### PR TITLE
Automate dormant GitHub users

### DIFF
--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -32,8 +32,9 @@ ALLOWED_BOT_USERS = [
     "laaserviceaccount",
 ]
 
-logging.basicConfig(level=logging.INFO,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
 
 def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_service, bot_list: list) -> list:
     all_users = github_service.get_all_enterprise_members()
@@ -41,7 +42,7 @@ def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_ser
     cloudtrail_service = CloudtrailService()
     active_users = cloudtrail_service.get_active_users()
 
-    return [ user for user in all_users if user not in list(set(active_users).union(bot_list)) ]
+    return [user for user in all_users if user not in list(set(active_users).union(bot_list))]
 
 
 def get_dormant_users_from_data_lake(github_service: GithubService) -> list:
@@ -70,7 +71,7 @@ def identify_dormant_github_users():
 
     dormant_users_from_csv = get_dormant_users_from_data_lake(GithubService(env.get('GH_ADMIN_TOKEN'), ORGANISATION))
 
-    dormant_users_accoding_to_github_and_auth0 = [ user for user in dormant_users_from_csv if user.is_dormant ]
+    dormant_users_accoding_to_github_and_auth0 = [user for user in dormant_users_from_csv if user.is_dormant]
 
     SlackService(env.get('ADMIN_SLACK_TOKEN')).send_message_to_plaintext_channel_name(message_to_slack_channel(dormant_users_accoding_to_github_and_auth0), SLACK_CHANNEL)
 

--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -40,7 +40,7 @@ def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_ser
     all_users = github_service.get_all_enterprise_members()
 
     cloudtrail_service = CloudtrailService()
-    active_users = cloudtrail_service.get_active_users()
+    active_users = cloudtrail_service.get_active_users_for_dormant_users_process()
 
     return [user for user in all_users if user not in list(set(active_users).union(bot_list))]
 
@@ -69,9 +69,9 @@ def message_to_slack_channel(list_of_dormant_users: list) -> str:
 def identify_dormant_github_users():
     env = EnvironmentVariables(["GH_ADMIN_TOKEN", "ADMIN_SLACK_TOKEN"])
 
-    dormant_users_from_csv = get_dormant_users_from_data_lake(GithubService(env.get('GH_ADMIN_TOKEN'), ORGANISATION))
+    dormant_users_according_to_github = get_dormant_users_from_data_lake(GithubService(env.get('GH_ADMIN_TOKEN'), ORGANISATION))
 
-    dormant_users_accoding_to_github_and_auth0 = [user for user in dormant_users_from_csv if user.is_dormant]
+    dormant_users_accoding_to_github_and_auth0 = [user for user in dormant_users_according_to_github if user.is_dormant]
 
     SlackService(env.get('ADMIN_SLACK_TOKEN')).send_message_to_plaintext_channel_name(message_to_slack_channel(dormant_users_accoding_to_github_and_auth0), SLACK_CHANNEL)
 

--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -1,9 +1,4 @@
-import csv
 import logging
-import os
-
-import boto3
-from botocore.exceptions import NoCredentialsError
 
 from services.dormant_github_user_service import DormantGitHubUser
 from services.github_service import GithubService
@@ -13,10 +8,7 @@ from utils.environment import EnvironmentVariables
 
 SLACK_CHANNEL = "operations-engineering-alerts"
 AUTH0_DOMAIN = "operations-engineering.eu.auth0.com"
-NUMBER_OF_DAYS_CONSIDERED_DORMANT = 90
-CSV_FILE_NAME = "dormant.csv"
 ORGANISATION = "ministryofjustice"
-BUCKET_NAME = "operations-engineering-dormant-users"
 # These are the users that are deemed acceptable to be dormant. They are either bots or service accounts and will be revisited regularly.
 ALLOWED_BOT_USERS = [
     "ci-hmcts",
@@ -40,8 +32,7 @@ ALLOWED_BOT_USERS = [
     "laaserviceaccount",
 ]
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_service, bot_list: list) -> list:

--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -37,12 +37,11 @@ logger = logging.getLogger(__name__)
 
 def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_service, bot_list: list) -> list:
     all_users = github_service.get_all_enterprise_members()
-    all_collaborators = github_service.get_all_enterprise_collaborators()
 
     cloudtrail_service = CloudtrailService()
     active_users = cloudtrail_service.get_active_users()
 
-    return [ user for user in all_users if user not in list(set(active_users).union(bot_list, all_collaborators)) ]
+    return [ user for user in all_users if user not in list(set(active_users).union(bot_list)) ]
 
 
 def get_dormant_users_from_data_lake(github_service: GithubService) -> list:

--- a/services/cloudtrail_service.py
+++ b/services/cloudtrail_service.py
@@ -6,9 +6,7 @@ class CloudtrailService:
     def __init__(self) -> None:
         self.client = boto3.client("cloudtrail", region_name="eu-west-2")
 
-
     def get_active_users(self):
-
         username_key = "eventData.useridentity.principalid"
         data_store_id = "ec682140-3e75-40c0-8e04-f06207791c2e"
         period_cutoff = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d %H:%M:%S')
@@ -23,14 +21,14 @@ class CloudtrailService:
 
         return self.get_query_results(query_id)
 
-
+    # pylint: disable=W0719
     def get_query_results(self, query_id):
         while True:
             status = self.client.get_query_results(QueryId=query_id)['QueryStatus']
             print(f"Query status: {status}")
             if status in ['FAILED', 'CANCELLED', 'TIMED_OUT']:
                 raise Exception(f"Cloudtrail data lake query failsed with status: {status}")
-            elif status == 'FINISHED':
+            if status == 'FINISHED':
                 return self.extract_query_results(query_id)
             time.sleep(20)
 

--- a/services/cloudtrail_service.py
+++ b/services/cloudtrail_service.py
@@ -1,0 +1,41 @@
+import boto3
+import time
+from datetime import datetime, timedelta
+
+class CloudtrailService:
+    def __init__(self) -> None:
+        self.client = boto3.client("cloudtrail")
+
+
+    def get_active_users(self):
+
+        username_key = "eventData.useridentity.principalid"
+        data_store_id = "ec682140-3e75-40c0-8e04-f06207791c2e"
+        period_cutoff = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d %H:%M:%S')
+
+        query_string = f"""
+        SELECT DISTINCT {username_key}
+        FROM {data_store_id}
+        WHERE eventTime > '{period_cutoff}';
+        """
+
+        query_id = self.client.start_query(QueryStatement=query_string)['QueryId']
+
+        return self.get_query_results(query_id)
+
+
+    def get_query_results(self, query_id):
+        while True:
+            response = self.client.get_query_results(QueryId=query_id)
+            status = response['QueryStatus']
+            print(f"Query status: {status}")
+            if status in ['FAILED', 'CANCELLED', 'TIMED_OUT']:
+                raise Exception(f"Cloudtrail data lake query failsed with status: {status}")
+            elif status == 'FINISHED':
+                return [list(row[0].values())[0] for row in response['QueryResultRows']]
+            time.sleep(20)
+
+    def get_query_status(self, query_id):
+        response = self.client.get_query_status(QueryId=query_id)
+
+        return response['QueryStatus']

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1242,11 +1242,3 @@ class GithubService:
             all_users = all_users + [user.login for user in self.github_client_core_api.get_organization(org).get_members() if user.login not in all_users]
 
         return all_users
-
-    def get_all_enterprise_collaborators(self) -> list:
-        all_collaborators = []
-
-        for org in self.organisations_in_enterprise:
-            all_collaborators = all_collaborators + [collaborator.login for collaborator in self.github_client_core_api.get_organization(org).get_outside_collaborators() if collaborator.login not in all_collaborators]
-
-        return all_collaborators

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -16,7 +16,7 @@ from requests import Session
 
 from config.logging_config import logging
 
-# pylint: disable=E1136, E1135
+# pylint: disable=E1136, E1135, W0718, C0411
 
 logging.getLogger("gql").setLevel(logging.WARNING)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1,3 +1,5 @@
+# pylint: disable=E1136, E1135, W0718, C0411
+
 import json
 from calendar import timegm
 from datetime import date, datetime, timedelta
@@ -15,8 +17,6 @@ from gql.transport.exceptions import TransportQueryError
 from requests import Session
 
 from config.logging_config import logging
-
-# pylint: disable=E1136, E1135, W0718, C0411
 
 logging.getLogger("gql").setLevel(logging.WARNING)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -71,6 +71,7 @@ class GithubService:
                  enterprise_name: str = ENTERPRISE_NAME) -> None:
         self.organisation_name: str = organisation_name
         self.enterprise_name: str = enterprise_name
+        self.organisations_in_enterprise: list = ["ministryofjustice", "moj-analytical-services"]
 
         self.github_client_core_api: Github = Github(org_token)
         self.github_client_gql_api: Client = Client(transport=AIOHTTPTransport(
@@ -1232,3 +1233,20 @@ class GithubService:
         logging.error(
             f"Failed to fetch PAT list: {response.status_code}, error: {response}")
         return []
+
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def get_all_enterprise_members(self) -> list:
+        all_users = []
+
+        for org in self.organisations_in_enterprise:
+            all_users = all_users + [user.login for user in self.github_client_core_api.get_organization(org).get_members() if user.login not in all_users]
+
+        return all_users
+
+    def get_all_enterprise_collaborators(self) -> list:
+        all_collaborators = []
+
+        for org in self.organisations_in_enterprise:
+            all_collaborators = all_collaborators + [collaborator.login for collaborator in self.github_client_core_api.get_organization(org).get_outside_collaborators() if collaborator.login not in all_collaborators]
+
+        return all_collaborators

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -13,7 +13,6 @@ class TestDormantGitHubUsers(unittest.TestCase):
     def setUp(self):
         self.allowed_bot_users = ["bot1", "bot2"]
 
-
     @patch('bin.identify_dormant_github_users.get_inactive_users_from_data_lake_ignoring_bots_and_collaborators')
     @patch('services.dormant_github_user_service.DormantGitHubUser')
     @patch('services.github_service.GithubService')

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -1,74 +1,39 @@
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
-
-from botocore.exceptions import ClientError, NoCredentialsError
+from unittest.mock import MagicMock, patch
 
 from bin.identify_dormant_github_users import (
-    ALLOWED_BOT_USERS, download_github_dormant_users_csv_from_s3,
-    get_dormant_users_from_github_csv,
-    get_usernames_from_csv_ignoring_bots_and_collaborators)
+    ALLOWED_BOT_USERS,
+    get_dormant_users_from_data_lake,
+    get_inactive_users_from_data_lake_ignoring_bots_and_collaborators)
 
+from services.cloudtrail_service import CloudtrailService
 
 class TestDormantGitHubUsers(unittest.TestCase):
 
     def setUp(self):
         self.allowed_bot_users = ["bot1", "bot2"]
 
-    @patch('bin.identify_dormant_github_users.download_github_dormant_users_csv_from_s3')
-    @patch('bin.identify_dormant_github_users.get_usernames_from_csv_ignoring_bots_and_collaborators')
+
+    @patch('bin.identify_dormant_github_users.get_inactive_users_from_data_lake_ignoring_bots_and_collaborators')
     @patch('services.dormant_github_user_service.DormantGitHubUser')
     @patch('services.github_service.GithubService')
-    def test_get_dormant_users_from_github_csv(self, mock_github_service, mock_dormant_github_user, mock_get_usernames, mock_download_csv):
-        mock_get_usernames.return_value = ['user1', 'user2', 'user3']
-
-        mock_dormant_github_user.side_effect = lambda github_service, user: MagicMock(
-            __str__=lambda: f'DormantGitHubUser({user})')
+    def test_get_dormant_users_from_data_lake(self, mock_github_service, mock_dormant_github_user, mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators):
+        mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators.return_value = ['user1', 'user2', 'user3']
         github_service = mock_github_service
+        mock_dormant_github_user.side_effect = lambda github_service, user: MagicMock(__str__=lambda: f'DormantGitHubUser({user})')
 
-        result = get_dormant_users_from_github_csv(github_service)
+        result = get_dormant_users_from_data_lake(github_service)
 
         self.assertEqual(len(result), 3)
-        mock_download_csv.assert_called_once()
-        mock_get_usernames.assert_called_once_with(ALLOWED_BOT_USERS)
+        mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators.assert_called_once_with(github_service, ALLOWED_BOT_USERS)
 
-    def test_get_usernames_from_csv_ignoring_bots_empty_csv(self):
-        mock_file_content = ""
-        with patch("builtins.open", mock_open(read_data=mock_file_content)):
-            result = get_usernames_from_csv_ignoring_bots_and_collaborators(
-                self.allowed_bot_users)
-        self.assertEqual(result, [])
+    @patch.object(CloudtrailService, "get_active_users")
+    def test_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(self, mock_get_active_users):
+        mock_get_active_users.return_value = ["member1"]
+        mock_github_service = MagicMock()
+        mock_github_service.get_all_enterprise_members = MagicMock(return_value=["member1", "member2", "bot1", "bot2"])
 
-    def test_get_usernames_from_csv_ignoring_bots_only_bots(self):
-        mock_file_content = "created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,bot2,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,bot1,user,31.121.104.4,true,false"
-        bot_list = ['bot1', 'bot2']
-        with patch("builtins.open", mock_open(read_data=mock_file_content)):
-            result = get_usernames_from_csv_ignoring_bots_and_collaborators(
-                bot_list=bot_list)
-        self.assertEqual(result, [])
-
-    def test_get_usernames_from_csv_ignoring_bots_and_collaborators(self):
-        mock_file_content = "created_at,id,login,role,last_logged_ip,2fa_enabled?,outside_collaborator\n2011-05-04 10:06:20 +0100,767430,joebloggs,user,165.225.16.122,true,false\n2012-06-19 10:02:40 +0100,1866734,jamesoutsidecollaborator,user,31.121.104.4,true,true"
-        bot_list = ['bot1', 'bot2']
-        with patch("builtins.open", mock_open(read_data=mock_file_content)):
-            usernames = get_usernames_from_csv_ignoring_bots_and_collaborators(
-                bot_list)
-        self.assertEqual(usernames, ['joebloggs'])
-
-    @patch('boto3.client')
-    def test_download_github_dormant_users_csv_from_s3_no_credentials(self, mock_boto3_client):
-        # Mock boto3 client to raise NoCredentialsError
-        mock_boto3_client.side_effect = NoCredentialsError
-        with self.assertRaises(NoCredentialsError):
-            download_github_dormant_users_csv_from_s3()
-
-    @patch('boto3.client')
-    def test_download_github_dormant_users_csv_from_s3_file_not_found(self, mock_boto3_client):
-        # Mock boto3 client to raise ClientError for a not found file
-        error_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
-        mock_boto3_client.side_effect = ClientError(
-            error_response, 'get_object')
-        with self.assertRaises(ClientError):
-            download_github_dormant_users_csv_from_s3()
+        assert get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(mock_github_service, self.allowed_bot_users) == ["member2"]
 
 
 if __name__ == '__main__':

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -26,9 +26,9 @@ class TestDormantGitHubUsers(unittest.TestCase):
         self.assertEqual(len(result), 3)
         mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators.assert_called_once_with(github_service, ALLOWED_BOT_USERS)
 
-    @patch.object(CloudtrailService, "get_active_users")
-    def test_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(self, mock_get_active_users):
-        mock_get_active_users.return_value = ["member1"]
+    @patch.object(CloudtrailService, "get_active_users_for_dormant_users_process")
+    def test_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(self, mock_get_active_users_for_dormant_users_process):
+        mock_get_active_users_for_dormant_users_process.return_value = ["member1"]
         mock_github_service = MagicMock()
         mock_github_service.get_all_enterprise_members = MagicMock(return_value=["member1", "member2", "bot1", "bot2"])
 

--- a/test/test_services/test_cloudtrail_service.py
+++ b/test/test_services/test_cloudtrail_service.py
@@ -12,7 +12,6 @@ class TestCloudtrailService(unittest.TestCase):
         self.cloudtrail_service = CloudtrailService()
         self.cloudtrail_service.client = boto3.client("cloudtrail", region_name="us-west-2")
 
-
     @freeze_time("2024-07-11 00:00:00")
     @patch.object(CloudtrailService, "get_query_results")
     @mock_aws
@@ -43,7 +42,6 @@ class TestCloudtrailService(unittest.TestCase):
         mock_extract_query_results.assert_called_once_with(mock_query_id)
         assert response == mock_active_users
 
-
     @mock_aws
     def test_get_query_results_if_fail(self):
         self.cloudtrail_service.client.get_query_results = MagicMock(return_value={'QueryStatus': 'CANCELLED'})
@@ -53,17 +51,16 @@ class TestCloudtrailService(unittest.TestCase):
         self.cloudtrail_service.client.get_query_results.assert_called_once_with(QueryId="mock_id")
         self.assertEqual(str(context.exception), "Cloudtrail data lake query failsed with status: CANCELLED")
 
-
+    # pylint: disable=C0103, W0613
     @mock_aws
     def test_extract_query_results(self):
-
         mock_next_token = "mock_next_token"
 
         def mock_get_query_results(QueryId=None, MaxQueryResults=1000, NextToken=False):
             if NextToken:
                 return {'QueryResultRows': [[{'principalId': 'test_user3'}]]}
-            else:
-                return {'NextToken': mock_next_token,'QueryResultRows': [[{'principalId': 'test_user1'}], [{'principalId': 'test_user2'}]]}
+
+            return {'NextToken': mock_next_token, 'QueryResultRows': [[{'principalId': 'test_user1'}], [{'principalId': 'test_user2'}]]}
 
         self.cloudtrail_service.client.get_query_results = MagicMock(side_effect=mock_get_query_results)
         mock_query_id = "mock_id"

--- a/test/test_services/test_cloudtrail_service.py
+++ b/test/test_services/test_cloudtrail_service.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import boto3
+from moto import mock_aws
+from services.cloudtrail_service import CloudtrailService
+from freezegun import freeze_time
+
+class TestCloudtrailService(unittest.TestCase):
+
+    @mock_aws
+    def setUp(self):
+        self.cloudtrail_service = CloudtrailService()
+        self.cloudtrail_service.client = boto3.client("cloudtrail", region_name="us-west-2")
+
+
+    @freeze_time("2024-07-11 00:00:00")
+    @patch.object(CloudtrailService, "get_query_results")
+    @mock_aws
+    def test_get_active_users(self, mock_query_results):
+        mock_active_users = ["user1", "user2", "user3"]
+        mock_query_results.return_value = mock_active_users
+        self.cloudtrail_service.client.start_query = MagicMock()
+        mock_query_string = """
+        SELECT DISTINCT eventData.useridentity.principalid
+        FROM ec682140-3e75-40c0-8e04-f06207791c2e
+        WHERE eventTime > '2024-04-12 00:00:00';
+        """
+
+        assert self.cloudtrail_service.get_active_users() == mock_active_users
+        self.cloudtrail_service.client.start_query.assert_called_once_with(QueryStatement=mock_query_string)
+
+    @patch.object(CloudtrailService, "extract_query_results")
+    @mock_aws
+    def test_get_query_results_if_success(self, mock_extract_query_results):
+        mock_active_users = ["user1", "user2", "user3"]
+        mock_extract_query_results.return_value = mock_active_users
+        self.cloudtrail_service.client.get_query_results = MagicMock(return_value={'QueryStatus': 'FINISHED'})
+        mock_query_id = "mock_id"
+
+        response = self.cloudtrail_service.get_query_results(mock_query_id)
+
+        self.cloudtrail_service.client.get_query_results.assert_called_once_with(QueryId=mock_query_id)
+        mock_extract_query_results.assert_called_once_with(mock_query_id)
+        assert response == mock_active_users
+
+
+    @mock_aws
+    def test_get_query_results_if_fail(self):
+        self.cloudtrail_service.client.get_query_results = MagicMock(return_value={'QueryStatus': 'CANCELLED'})
+        with self.assertRaises(Exception) as context:
+            self.cloudtrail_service.get_query_results("mock_id")
+
+        self.cloudtrail_service.client.get_query_results.assert_called_once_with(QueryId="mock_id")
+        self.assertEqual(str(context.exception), "Cloudtrail data lake query failsed with status: CANCELLED")
+
+
+    @mock_aws
+    def test_extract_query_results(self):
+
+        mock_next_token = "mock_next_token"
+
+        def mock_get_query_results(QueryId=None, MaxQueryResults=1000, NextToken=False):
+            if NextToken:
+                return {'QueryResultRows': [[{'principalId': 'test_user3'}]]}
+            else:
+                return {'NextToken': mock_next_token,'QueryResultRows': [[{'principalId': 'test_user1'}], [{'principalId': 'test_user2'}]]}
+
+        self.cloudtrail_service.client.get_query_results = MagicMock(side_effect=mock_get_query_results)
+        mock_query_id = "mock_id"
+
+        assert self.cloudtrail_service.extract_query_results(mock_query_id) == ["test_user1", "test_user2", "test_user3"]
+        self.cloudtrail_service.client.get_query_results.assert_has_calls([call(QueryId=mock_query_id, MaxQueryResults=1000), call(QueryId=mock_query_id, MaxQueryResults=1000, NextToken=mock_next_token)])

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1838,5 +1838,33 @@ class TestGithubServicePATRetrieval(unittest.TestCase):
         mock_get_new_pat_creation_events.assert_called_once()
 
 
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
+@patch("github.Github.__new__")
+class TestGithubServiceGetAllEnterpriseCollaborators(unittest.TestCase):
+
+    def test_get_all_enterprise_collaborators(self, mock_github_client_core_api):
+        mock_github_client_core_api.return_value.get_organization().get_outside_collaborators.return_value = [
+            Mock(NamedUser),
+            Mock(NamedUser),
+        ]
+        response = GithubService("", ORGANISATION_NAME).get_all_enterprise_collaborators()
+        self.assertEqual(2, len(response))
+
+
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
+@patch("github.Github.__new__")
+class TestGithubServiceGetAllEnterpriseMembers(unittest.TestCase):
+
+    def test_get_all_enterprise_members(self, mock_github_client_core_api):
+        mock_github_client_core_api.return_value.get_organization().get_members.return_value = [
+            Mock(NamedUser),
+            Mock(NamedUser),
+        ]
+        response = GithubService("", ORGANISATION_NAME).get_all_enterprise_members()
+        self.assertEqual(2, len(response))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1841,20 +1841,6 @@ class TestGithubServicePATRetrieval(unittest.TestCase):
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__")
-class TestGithubServiceGetAllEnterpriseCollaborators(unittest.TestCase):
-
-    def test_get_all_enterprise_collaborators(self, mock_github_client_core_api):
-        mock_github_client_core_api.return_value.get_organization().get_outside_collaborators.return_value = [
-            Mock(NamedUser),
-            Mock(NamedUser),
-        ]
-        response = GithubService("", ORGANISATION_NAME).get_all_enterprise_collaborators()
-        self.assertEqual(2, len(response))
-
-
-@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
-@patch("gql.Client.__new__", new=MagicMock)
-@patch("github.Github.__new__")
 class TestGithubServiceGetAllEnterpriseMembers(unittest.TestCase):
 
     def test_get_all_enterprise_members(self, mock_github_client_core_api):


### PR DESCRIPTION
- Adds cloudtrail service to query data lake
- Adds function to retrieve all members of enterprise to github service
- Adds functions to identify dormant users job to compute inactive users from data lake source. These functions replace the old ones which use manually generated csv as a source.
- Unit tests.