### PR TITLE
🧪 Test Authentication to Cloud Platform Route53

### DIFF
--- a/.github/workflows/experiment-cloud-platform-route53-read.yml
+++ b/.github/workflows/experiment-cloud-platform-route53-read.yml
@@ -2,9 +2,6 @@ name: 🧪 Cloud Platform Read Route53
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
 
 jobs:
   cloud-platform-read-route53:

--- a/.github/workflows/experiment-cloud-platform-route53-read.yml
+++ b/.github/workflows/experiment-cloud-platform-route53-read.yml
@@ -19,12 +19,15 @@ jobs:
         with:
           role-to-assume: ${{ secrets.ASSUME_CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
           aws-region: eu-west-2
+          role-session-name: AssumeCPRoleSession
 
       - name: Configure AWS Credentials - Role with Read Access to Cloud Platforms Route53
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
           aws-region: eu-west-2
+          role-session-name: AssumeCPRoleSession
+          role-chaining: true
 
       - name: Check Access
         run: |

--- a/.github/workflows/experiment-cloud-platform-route53-read.yml
+++ b/.github/workflows/experiment-cloud-platform-route53-read.yml
@@ -1,0 +1,31 @@
+name: 🧪 Cloud Platform Read Route53
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  backup-route-53:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials - Role to Assume Cloud Platforms Route53 Read Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ASSUME_CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Configure AWS Credentials - Role with Read Access to Cloud Platforms Route53
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Check Access
+        run: |
+          aws route53 list-hosted-zones --max-items="1" --output="json" | jq ".HostedZones[].Name"

--- a/.github/workflows/experiment-cloud-platform-route53-read.yml
+++ b/.github/workflows/experiment-cloud-platform-route53-read.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  backup-route-53:
+  cloud-platform-read-route53:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -19,14 +19,13 @@ jobs:
         with:
           role-to-assume: ${{ secrets.ASSUME_CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
           aws-region: eu-west-2
-          role-session-name: AssumeCPRoleSession
 
       - name: Configure AWS Credentials - Role with Read Access to Cloud Platforms Route53
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
           aws-region: eu-west-2
-          role-session-name: AssumeCPRoleSession
+          role-skip-session-tagging: true
           role-chaining: true
 
       - name: Check Access


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4523
- In relation to https://github.com/ministryofjustice/cloud-platform/issues/5727#issuecomment-2174133535
- To test authentication to Cloud Platforms Route53 (read-only access)

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added new workflow which assumes the OE role to assume the CP role and tests authentication by trying to list the hosted zones 
- Added `CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN` secret to this repository

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- Ideally, we want to build this access into some service, product or part of change process, but going to draft up a separate ticket to get that in place
- Can see that this integrated correctly in this run of the action 👉 https://github.com/ministryofjustice/operations-engineering/actions/runs/9939205430/job/27453297647#step:5:11 👈 

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
