### PR TITLE
GitHub Secret Injection Through Module

### DIFF
--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -98,6 +98,6 @@ jobs:
             ```
 
       - name: Terraform Apply
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         id: apply
         run: terraform apply -input=false -no-color -auto-approve

--- a/terraform/github/repositories/ministryofjustice/test-tamf-repo-2.tf
+++ b/terraform/github/repositories/ministryofjustice/test-tamf-repo-2.tf
@@ -8,4 +8,5 @@ module "test_tamf_repo_2" {
   team_access = {
     maintain = [var.operations_engineering_team_id]
   }
+  secrets     = {EXAMPLE_SECRET = "EXAMPLE_SECRET_VALUE"}
 }

--- a/terraform/github/repositories/ministryofjustice/test-tamf-repo-2.tf
+++ b/terraform/github/repositories/ministryofjustice/test-tamf-repo-2.tf
@@ -8,5 +8,14 @@ module "test_tamf_repo_2" {
   team_access = {
     maintain = [var.operations_engineering_team_id]
   }
-  secrets     = {EXAMPLE_SECRET = "EXAMPLE_SECRET_VALUE"}
+  secrets     = {EXAMPLE_SECRET = jsondecode(data.aws_secretsmanager_secret_version.example_secret_version.secret_string)["EXAMPLE_SECRET"]}
 }
+
+data "aws_secretsmanager_secret" "example_secret" {
+  name = "EXAMPLE_SECRET"
+}
+
+data "aws_secretsmanager_secret_version" "example_secret_version" {
+  secret_id = data.aws_secretsmanager_secret.example_secret.id
+}
+


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

To prove that it's possible to add GitHub secrets through Terraform, and reference the value in AWS Secrets Manager.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Secrets values are now passed through and created by the module. 
- An example of this is in the test-tamf-repo-2 using the one EXAMPLE_SECRET from AWS.

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes
•

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [x] I have checked that all new dependencies are up to date and necessary.
