### PR TITLE
:green_heart: Add notifiy-slack-action steps to all pipelines + Use Commit SHA

### DIFF
--- a/.github/workflows/cicd-terraform-auth0.yml
+++ b/.github/workflows/cicd-terraform-auth0.yml
@@ -102,3 +102,13 @@ jobs:
         if: github.ref == 'refs/heads/main'
         id: apply
         run: terraform apply -input=false -no-color -auto-approve
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cicd-terraform-dsd-iam.yml
+++ b/.github/workflows/cicd-terraform-dsd-iam.yml
@@ -107,3 +107,13 @@ jobs:
         if: github.ref == 'refs/heads/main'
         id: apply
         run: terraform apply -input=false -no-color -auto-approve
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cicd-terraform-github-repos.yml
+++ b/.github/workflows/cicd-terraform-github-repos.yml
@@ -56,7 +56,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
+          repo-token-user-login: "github-actions[bot]"
           message: |
             Your PR is applying here: https://github.com/ministryofjustice/operations-engineering/actions/workflows/cicd-terraform-github-repos.yml?query=event%3Apush+branch%3Amain
 
@@ -79,18 +79,18 @@ jobs:
       - name: Delete Old Comments
         uses: maheshrayas/action-pr-comment-delete@v3.0
         with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
           org: ministryofjustice
           repo: operations-engineering
-          user: 'github-actions[bot]'
-          issue: '${{github.event.number}}'
+          user: "github-actions[bot]"
+          issue: "${{github.event.number}}"
 
       - name: Post Plan to GitHub PR
         if: github.ref != 'refs/heads/main'
         uses: mshick/add-pr-comment@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]'
+          repo-token-user-login: "github-actions[bot]"
           message: |
             ## Terraform github repositories plan
             ```
@@ -101,3 +101,13 @@ jobs:
         if: github.ref == 'refs/heads/main'
         id: apply
         run: terraform apply -input=false -no-color -auto-approve
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cicd-terraform-github-teams.yml
+++ b/.github/workflows/cicd-terraform-github-teams.yml
@@ -89,3 +89,13 @@ jobs:
         if: github.ref == 'refs/heads/main'
         id: apply
         run: terraform apply -input=false -no-color -auto-approve
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # v2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cicd-terraform-s3-to-cloudtrail.yml
+++ b/.github/workflows/cicd-terraform-s3-to-cloudtrail.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Report failure to Slack
         if: ${{ always() && github.ref == 'refs/heads/main' }}
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-add-github-members-to-root-team-moj.yml
+++ b/.github/workflows/job-add-github-members-to-root-team-moj.yml
@@ -24,7 +24,7 @@ jobs:
           LOGGING_LEVEL: ${{ secrets.LOGGING_LEVEL }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-add-github-members-to-root-team-mojas.yml
+++ b/.github/workflows/job-add-github-members-to-root-team-mojas.yml
@@ -24,7 +24,7 @@ jobs:
           LOGGING_LEVEL: ${{ secrets.LOGGING_LEVEL }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-alarm-for-github-actions-quota.yml
+++ b/.github/workflows/job-alarm-for-github-actions-quota.yml
@@ -25,7 +25,7 @@ jobs:
       - run: pipenv run python3 -m bin.alert_on_low_github_actions_quota
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-alarm-for-low-github-seats.yaml
+++ b/.github/workflows/job-alarm-for-low-github-seats.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-alarm-for-new-github-owners.yml
+++ b/.github/workflows/job-alarm-for-new-github-owners.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-alarm-unowned-repository.yaml
+++ b/.github/workflows/job-alarm-unowned-repository.yaml
@@ -24,7 +24,7 @@ jobs:
           ADMIN_SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-apply-standards.yml
+++ b/.github/workflows/job-apply-standards.yml
@@ -25,7 +25,7 @@ jobs:
           KPI_DASHBOARD_API_KEY: ${{ secrets.KPI_DASHBOARD_POC_API_KEY }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-archive-inactive-repos-moj.yml
+++ b/.github/workflows/job-archive-inactive-repos-moj.yml
@@ -25,7 +25,7 @@ jobs:
           LOGGING_LEVEL: ${{ secrets.LOGGING_LEVEL }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-archive-inactive-repos-mojas.yml
+++ b/.github/workflows/job-archive-inactive-repos-mojas.yml
@@ -25,7 +25,7 @@ jobs:
           LOGGING_LEVEL: ${{ secrets.LOGGING_LEVEL }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-delete-auth0-inactve-users.yml
+++ b/.github/workflows/job-delete-auth0-inactve-users.yml
@@ -23,3 +23,13 @@ jobs:
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN}}
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-fetch-github-joiner-metrics.yml
+++ b/.github/workflows/job-fetch-github-joiner-metrics.yml
@@ -23,3 +23,13 @@ jobs:
           ADMIN_GITHUB_TOKEN: ${{ secrets.GH_BOT_AUDIT_LOG_PAT_TOKEN }}
           ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-generate-github-standards-report.yaml
+++ b/.github/workflows/job-generate-github-standards-report.yaml
@@ -21,7 +21,7 @@ jobs:
       - run: pipenv run python3 -m bin.report_on_repository_standards --oauth-token ${{ secrets.OPS_ENG_GENERAL_ADMIN_BOT_PAT }} --api-key ${{ secrets.REPORTS_API_KEY }} --url https://operations-engineering-reports-prod.cloud-platform.service.justice.gov.uk --endpoint /api/v2/update-github-reports
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/job-generate-pat-token-report.yml
+++ b/.github/workflows/job-generate-pat-token-report.yml
@@ -28,3 +28,13 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-send-support-stats-to-slack.yml
+++ b/.github/workflows/job-send-support-stats-to-slack.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'data/support_stats/support_stats.csv'
+      - "data/support_stats/support_stats.csv"
     branches: ["main"]
 jobs:
   send-support-stats-to-slack:
@@ -22,4 +22,14 @@ jobs:
       - run: pipenv run python3 -m bin.support_stats_reporting
         env:
           ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/job-sentry-usage-alert.yml
+++ b/.github/workflows/job-sentry-usage-alert.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       period_in_days:
-        description: 'Period in days'
+        description: "Period in days"
         required: false
         type: string
       usage_threshold:
-        description: 'Usage threshold (%)'
+        description: "Usage threshold (%)"
         required: false
         type: string
 
@@ -36,7 +36,7 @@ jobs:
           LOGGING_LEVEL: ${{ secrets.LOGGING_LEVEL }}
       - name: Report failure to Slack
         if: always()
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
         with:
           status: ${{ job.status }}
           notify_when: "failure"

--- a/.github/workflows/test-get-audit-log-users.yml
+++ b/.github/workflows/test-get-audit-log-users.yml
@@ -19,3 +19,13 @@ jobs:
       - run: pipenv run python3 -m bin.identify_dormant_github_users
         env:
           GH_ADMIN_TOKEN: ${{ secrets.GH_BOT_AUDIT_LOG_PAT_TOKEN }}
+
+      - name: Report failure to Slack
+        if: ${{ always() && github.ref == 'refs/heads/main' }}
+        uses: ravsamhq/notify-slack-action@472601e839b758e36c455b5d3e5e1a217d4807bd # 2.5.0
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Failed GitHub Action Run"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This commit adds the notify-slack-action step to all GitHub workflows that don't already implement an alert feature upon failure. This ensures that we don't ignore failing pipelines. The commit also uses the commit SHA over the version number as suggested by GitHub.
