### PR TITLE
✨ Add DNS Delegation Metrics Workflow

### DIFF
--- a/.github/workflows/experiment-dns-delegations-metrics.yml
+++ b/.github/workflows/experiment-dns-delegations-metrics.yml
@@ -2,9 +2,6 @@ name: 🧪 DNS Delegations Metrics
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
 
 jobs:
   dns-delegations-metrics:

--- a/.github/workflows/experiment-dns-delegations-metrics.yml
+++ b/.github/workflows/experiment-dns-delegations-metrics.yml
@@ -1,0 +1,40 @@
+name: 🧪 DNS Delegations Metrics
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  dns-delegations-metrics:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials - Role to Assume Cloud Platforms Route53 Read Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ASSUME_CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Configure AWS Credentials - Role with Read Access to Cloud Platforms Route53
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CLOUD_PLATFORM_ROUTE53_READ_ROLE_ARN }}
+          aws-region: eu-west-2
+          role-skip-session-tagging: true
+          role-chaining: true
+
+      - name: Create Profile to With ReadOnly Access to Cloud Platforms Route53
+        run: |
+          aws configure set region ${{ env.AWS_REGION }} --profile="cloud_platform_route53_read" 
+          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile="cloud_platform_route53_read"
+          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile="cloud_platform_route53_read"
+          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile="cloud_platform_route53_read"
+
+      - name: Check Access
+        run: |
+          aws route53 list-hosted-zones --max-items="1" --profile="cloud_platform_route53_read" --output="json" | jq ".HostedZones[].Name"

--- a/.github/workflows/experiment-dns-delegations-metrics.yml
+++ b/.github/workflows/experiment-dns-delegations-metrics.yml
@@ -14,6 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure AWS Credentials - Role with Read Access to DSD Route53
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DSD_ROUTE53_READ_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Create Profile to With ReadOnly Access to DSD Route53
+        run: |
+          aws configure set region ${{ env.AWS_REGION }} --profile="dsd_route53_read"
+          aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile="dsd_route53_read"
+          aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile="dsd_route53_read"
+          aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile="dsd_route53_read"
+
       - name: Configure AWS Credentials - Role to Assume Cloud Platforms Route53 Read Role
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -30,11 +43,12 @@ jobs:
 
       - name: Create Profile to With ReadOnly Access to Cloud Platforms Route53
         run: |
-          aws configure set region ${{ env.AWS_REGION }} --profile="cloud_platform_route53_read" 
+          aws configure set region ${{ env.AWS_REGION }} --profile="cloud_platform_route53_read"
           aws configure set aws_access_key_id ${{ env.AWS_ACCESS_KEY_ID }} --profile="cloud_platform_route53_read"
           aws configure set aws_secret_access_key ${{ env.AWS_SECRET_ACCESS_KEY }} --profile="cloud_platform_route53_read"
           aws configure set aws_session_token ${{ env.AWS_SESSION_TOKEN }} --profile="cloud_platform_route53_read"
 
       - name: Check Access
         run: |
+          aws route53 list-hosted-zones --max-items="1" --profile="dsd_route53_read" --output="json" | jq ".HostedZones[].Name"
           aws route53 list-hosted-zones --max-items="1" --profile="cloud_platform_route53_read" --output="json" | jq ".HostedZones[].Name"


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4653
- To add a basic workflow which shows that multiple profiles can be used to retrieve DNS information across multiple accounts (DSD and Cloud Platform)

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added the `DNS Delegations Metrics` Workflow

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- This isn't the final script, just the initial setup of the workflow to ensure we can get the right credentials set up. The next iterations will convert the basic bash script into a more comprehensive Python script to gather the metrics 📊

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
