### PR TITLE
✨ Add DSD Route53 Read Role

### DIFF
--- a/terraform/dsd/iam/dsd_route53_read_role.tf
+++ b/terraform/dsd/iam/dsd_route53_read_role.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_role" "dsd_route53_read_role" {
+  name               = "dsd_route53_read_role"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role_policy_document.json
+}
+
+data "aws_iam_policy" "dsd_route53_read_role_policy" {
+  arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "dsd_route53_read_role_policy_attatchment" {
+  role       = aws_iam_role.dsd_route53_read_role.name
+  policy_arn = data.aws_iam_policy.dsd_route53_read_role_policy.arn
+}
+
+resource "github_actions_secret" "dsd_route53_read_role_arn" {
+  repository      = "operations-engineering"
+  secret_name     = "DSD_ROUTE53_READ_ROLE_ARN"
+  plaintext_value = aws_iam_role.dsd_route53_read_role.arn
+}

--- a/terraform/dsd/iam/dsd_route53_read_role.tf
+++ b/terraform/dsd/iam/dsd_route53_read_role.tf
@@ -4,7 +4,7 @@ resource "aws_iam_role" "dsd_route53_read_role" {
 }
 
 data "aws_iam_policy" "dsd_route53_read_role_policy" {
-  arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "dsd_route53_read_role_policy_attatchment" {


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4653
- To enable read only access to the DSD accounts Route53

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added a new role for Read access to Route53 which can be assumed by this repository

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- NA

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
