### PR TITLE
✨ Add Script For DNS Delegation Metrics

### DIFF
--- a/.github/workflows/experiment-dns-delegations-metrics.yml
+++ b/.github/workflows/experiment-dns-delegations-metrics.yml
@@ -2,9 +2,6 @@ name: 🧪 DNS Delegations Metrics
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
 
 jobs:
   dns-delegations-metrics:

--- a/.github/workflows/experiment-dns-delegations-metrics.yml
+++ b/.github/workflows/experiment-dns-delegations-metrics.yml
@@ -2,6 +2,9 @@ name: 🧪 DNS Delegations Metrics
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   dns-delegations-metrics:
@@ -49,3 +52,16 @@ jobs:
         run: |
           aws route53 list-hosted-zones --max-items="1" --profile="dsd_route53_read" --output="json" | jq ".HostedZones[].Name"
           aws route53 list-hosted-zones --max-items="1" --profile="cloud_platform_route53_read" --output="json" | jq ".HostedZones[].Name"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pipenv"
+
+      - name: Install Pipenv
+        run: |
+          pip install pipenv
+          pipenv install
+
+      - name: Execute DNS Delegations Metrics Script
+        run: pipenv run python3 -m bin.dns_delegations_metrics

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -127,10 +127,8 @@ def main():
             type="HOSTED_ZONES", name=f"DSD - {hosted_zone.name}"
         )
         for record_set in hosted_zone.record_sets:
-            is_delegation = (
-                True
-                if record_set.type == "NS" and record_set.name != hosted_zone.name
-                else False
+            is_delegation = bool(
+                record_set.type == "NS" and record_set.name != hosted_zone.name
             )
 
             if not is_delegation:

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -1,28 +1,51 @@
+import logging
+
 from services.route53_service import (
+    HostedZoneModel,
     RecordSetModel,
     RecordValueModel,
     Route53Service,
-    HostedZoneModel,
 )
 
 
+def __flatten_record_value(record_values: list[RecordValueModel]) -> list[str]:
+    return [record.value for record in record_values]
+
+
 def __is_delegated_to_hosted_zones(
-    hosted_zones: list[HostedZoneModel], name_server_record: list[RecordValueModel]
-):
+    hosted_zones: list[HostedZoneModel], name_server_record: RecordSetModel
+) -> bool:
     for hosted_zone in hosted_zones:
-        hosted_zones_name_servers: RecordSetModel
+        print(f"Checking if Delegated to HostedZone: [ {hosted_zone.name} ]")
+
+        if hosted_zone.name != name_server_record.name:
+            # print("Not Delegated Because HostedZone Name Does Not Match Record Name")
+            continue
+
+        hosted_zones_name_servers: RecordSetModel | bool = False
 
         for record_set in hosted_zone.record_sets:
             if record_set.name == hosted_zone.name and record_set.type == "NS":
                 hosted_zones_name_servers = record_set
 
-        if (
-            hosted_zones_name_servers
-            and hosted_zones_name_servers == name_server_record
-        ):
+        if not hosted_zones_name_servers:
+            logging.warn(f"HostedZone [ ${hosted_zone.name} ] does not have NS record")
+            continue
+
+        name_servers_to_check = __flatten_record_value(name_server_record.values)
+        hosted_zone_name_servers = __flatten_record_value(
+            hosted_zones_name_servers and hosted_zones_name_servers.values
+        )
+
+        if hosted_zone.name == "et.dsd.io.":
+            print(f"HostedZone NameServers Flat: [ ${hosted_zone_name_servers} ]")
+            print(f"Delegation NameServers Flat: [ ${name_servers_to_check} ]")
+
+        if name_servers_to_check == hosted_zone_name_servers:
+            print("Found Delegation!")
             return True
-        else:
-            return False
+
+    return False
 
 
 def main():
@@ -51,7 +74,7 @@ def main():
             )
             if is_delegation:
                 print("Checking Delegation: ", record_set)
-                if __is_delegated_to_hosted_zones(dsd_hosted_zones, record_set.values):
+                if __is_delegated_to_hosted_zones(dsd_hosted_zones, record_set):
                     internal_delgations_count += 1
                     print(record_set.name, "delegated internally")
 

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -1,0 +1,15 @@
+from services.route53_service import Route53Service
+
+
+def main():
+    dsd_route53_service = Route53Service(profile="dsd_route53_read")
+    cloud_platform_route53_service = Route53Service(
+        profile="cloud_platform_route53_read"
+    )
+
+    print(dsd_route53_service.get_route53_hosted_zones()[0].name)
+    print(cloud_platform_route53_service.get_route53_hosted_zones()[0].name)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -1,5 +1,28 @@
-from services.route53_service import Route53Service, HostedZoneModel
-import json
+from services.route53_service import (
+    RecordSetModel,
+    RecordValueModel,
+    Route53Service,
+    HostedZoneModel,
+)
+
+
+def __is_delegated_to_hosted_zones(
+    hosted_zones: list[HostedZoneModel], name_server_record: list[RecordValueModel]
+):
+    for hosted_zone in hosted_zones:
+        hosted_zones_name_servers: RecordSetModel
+
+        for record_set in hosted_zone.record_sets:
+            if record_set.name == hosted_zone.name and record_set.type == "NS":
+                hosted_zones_name_servers = record_set
+
+        if (
+            hosted_zones_name_servers
+            and hosted_zones_name_servers == name_server_record
+        ):
+            return True
+        else:
+            return False
 
 
 def main():
@@ -13,12 +36,26 @@ def main():
         cloud_platform_route53_service.get_hosted_zones()
     )
 
-    print(json.dumps(dsd_hosted_zones[0].__dict__, default=lambda o: o.__dict__))
-    print(
-        json.dumps(
-            cloud_platform_hosted_zones[0].__dict__, default=lambda o: o.__dict__
-        )
-    )
+    internal_delgations_count = 0
+    cloud_platform_delegations_count = 0
+    unknown_delegations_count = 0
+
+    for hosted_zone in dsd_hosted_zones:
+        print("Checking HostedZone:", hosted_zone.name)
+        for record_set in hosted_zone.record_sets:
+            print("Checking RecordSet:", record_set.name)
+            is_delegation = (
+                True
+                if record_set.type == "NS" and record_set.name != hosted_zone.name
+                else False
+            )
+            if is_delegation:
+                print("Checking Delegation: ", record_set)
+                if __is_delegated_to_hosted_zones(dsd_hosted_zones, record_set.values):
+                    internal_delgations_count += 1
+                    print(record_set.name, "delegated internally")
+
+    print(internal_delgations_count)
 
 
 if __name__ == "__main__":

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-import logging
+from config.logging_config import logging
 import json
 from services.route53_service import (
     HostedZoneModel,
@@ -31,11 +30,13 @@ def __is_delegated_to_hosted_zones(
             continue
 
         name_servers_to_check = __flatten_record_value(name_server_record.values)
-        hosted_zone_name_servers = __flatten_record_value(
+        hosted_zone_name_servers_to_check = __flatten_record_value(
             hosted_zones_name_servers and hosted_zones_name_servers.values
         )
+        name_servers_to_check.sort()
+        hosted_zone_name_servers_to_check.sort()
 
-        if name_servers_to_check == hosted_zone_name_servers:
+        if name_servers_to_check == hosted_zone_name_servers_to_check:
             return True
 
     return False
@@ -89,7 +90,7 @@ def main():
                     unknown_delegations_count += 1
                     unkown_delegated_domains.append(record_set.name)
 
-    print(
+    logging.info(
         json.dumps(
             {
                 "totals": {

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -1,4 +1,5 @@
-from services.route53_service import Route53Service
+from services.route53_service import Route53Service, HostedZoneModel
+import json
 
 
 def main():
@@ -7,8 +8,17 @@ def main():
         profile="cloud_platform_route53_read"
     )
 
-    print(dsd_route53_service.get_route53_hosted_zones()[0].name)
-    print(cloud_platform_route53_service.get_route53_hosted_zones()[0].name)
+    dsd_hosted_zones: list[HostedZoneModel] = dsd_route53_service.get_hosted_zones()
+    cloud_platform_hosted_zones: list[HostedZoneModel] = (
+        cloud_platform_route53_service.get_hosted_zones()
+    )
+
+    print(json.dumps(dsd_hosted_zones[0].__dict__, default=lambda o: o.__dict__))
+    print(
+        json.dumps(
+            cloud_platform_hosted_zones[0].__dict__, default=lambda o: o.__dict__
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -6,6 +6,17 @@ from services.route53_service import (
     RecordValueModel,
     Route53Service,
 )
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Delegations:
+    type: str
+    name: str
+    all: list = field(default_factory=list)
+    to_dsd: list = field(default_factory=list)
+    to_cloud_platform: list = field(default_factory=list)
+    to_unknown: list = field(default_factory=list)
 
 
 def __flatten_record_value(record_values: list[RecordValueModel]) -> list[str]:
@@ -53,59 +64,55 @@ def main():
         cloud_platform_route53_service.get_hosted_zones()
     )
 
-    internal_delgations_count = 0
-    cloud_platform_delegations_count = 0
-    unknown_delegations_count = 0
-    total_delegations = 0
-
-    delegated_domains = []
-    cloud_platform_delegated_domains = []
-    internal_delegated_domains = []
-    unkown_delegated_domains = []
+    dsd_delegations = Delegations(type="ACCOUNT", name="DSD")
+    delegations: list[Delegations] = [dsd_delegations]
 
     for hosted_zone in dsd_hosted_zones:
+        hosted_zone_delegations = Delegations(
+            type="HOSTED_ZONES", name=f"DSD - {hosted_zone.name}"
+        )
         for record_set in hosted_zone.record_sets:
             is_delegation = (
                 True
                 if record_set.type == "NS" and record_set.name != hosted_zone.name
                 else False
             )
-            if is_delegation:
-                found_delegation = False
-                total_delegations += 1
-                delegated_domains.append(record_set.name)
-                if __is_delegated_to_hosted_zones(dsd_hosted_zones, record_set):
-                    internal_delgations_count += 1
-                    internal_delegated_domains.append(record_set.name)
-                    found_delegation = True
 
-                if __is_delegated_to_hosted_zones(
-                    cloud_platform_hosted_zones, record_set
-                ):
-                    cloud_platform_delegations_count += 1
-                    cloud_platform_delegated_domains.append(record_set.name)
-                    found_delegation = True
+            if not is_delegation:
+                continue
 
-                if not found_delegation:
-                    unknown_delegations_count += 1
-                    unkown_delegated_domains.append(record_set.name)
+            found_delegation = False
+            hosted_zone_delegations.all.append(record_set.name)
+            dsd_delegations.all.append(record_set.name)
+
+            if __is_delegated_to_hosted_zones(dsd_hosted_zones, record_set):
+                hosted_zone_delegations.to_dsd.append(record_set.name)
+                dsd_delegations.to_dsd.append(record_set.name)
+                found_delegation = True
+
+            if __is_delegated_to_hosted_zones(cloud_platform_hosted_zones, record_set):
+                hosted_zone_delegations.to_cloud_platform.append(record_set.name)
+                dsd_delegations.to_cloud_platform.append(record_set.name)
+                found_delegation = True
+
+            if not found_delegation:
+                hosted_zone_delegations.to_unknown.append(record_set.name)
+                dsd_delegations.to_unknown.append(record_set.name)
+
+        delegations.append(hosted_zone_delegations)
 
     logging.info(
         json.dumps(
             {
                 "totals": {
-                    "all": total_delegations,
-                    "unknownDelegations": unknown_delegations_count,
-                    "internalDelegations": internal_delgations_count,
-                    "cloudPlatformDelegations": cloud_platform_delegations_count,
+                    "all": len(dsd_delegations.all),
+                    "unknownDelegations": len(dsd_delegations.to_unknown),
+                    "internalDelegations": len(dsd_delegations.to_dsd),
+                    "cloudPlatformDelegations": len(dsd_delegations.to_cloud_platform),
                 },
-                "delegations": {
-                    "all": delegated_domains,
-                    "cloudPlatform": cloud_platform_delegated_domains,
-                    "internal": internal_delegated_domains,
-                    "unkown": unkown_delegated_domains,
-                },
-            }
+                "delegations": delegations,
+            },
+            default=lambda o: o.__dict__,
         )
     )
 

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -37,7 +37,9 @@ def __is_delegated_to_hosted_zones(
                 hosted_zones_name_servers = record_set
 
         if not hosted_zones_name_servers:
-            logging.warn(f"HostedZone [ ${hosted_zone.name} ] does not have NS record")
+            logging.warning(
+                f"HostedZone [ ${hosted_zone.name} ] does not have NS record"
+            )
             continue
 
         name_servers_to_check = __flatten_record_value(name_server_record.values)
@@ -51,6 +53,10 @@ def __is_delegated_to_hosted_zones(
             return True
 
     return False
+
+
+def __convert_to_percentage(partial: int, total: int) -> str:
+    return f"{round((partial / total) * 100)}%"
 
 
 def __show_as_json(
@@ -67,10 +73,30 @@ def __show_as_json(
                 "type": delegation.type,
                 "name": delegation.name,
                 "totals": {
-                    "all": len(delegation.all),
-                    "to_unknown": len(delegation.to_unknown),
-                    "to_cloud_platform": len(delegation.to_cloud_platform),
-                    "to_dsd": len(delegation.to_dsd),
+                    "all": [
+                        len(delegation.all),
+                        __convert_to_percentage(
+                            len(delegation.all), len(delegation.all)
+                        ),
+                    ],
+                    "to_unknown": [
+                        len(delegation.to_unknown),
+                        __convert_to_percentage(
+                            len(delegation.to_unknown), len(delegation.all)
+                        ),
+                    ],
+                    "to_cloud_platform": [
+                        len(delegation.to_cloud_platform),
+                        __convert_to_percentage(
+                            len(delegation.to_cloud_platform), len(delegation.all)
+                        ),
+                    ],
+                    "to_dsd": [
+                        len(delegation.to_dsd),
+                        __convert_to_percentage(
+                            len(delegation.to_dsd), len(delegation.all)
+                        ),
+                    ],
                 },
                 "all": delegation.all,
                 "to_unknown": delegation.to_unknown,

--- a/bin/dns_delegations_metrics.py
+++ b/bin/dns_delegations_metrics.py
@@ -57,6 +57,11 @@ def main():
     unknown_delegations_count = 0
     total_delegations = 0
 
+    delegated_domains = []
+    cloud_platform_delegated_domains = []
+    internal_delegated_domains = []
+    unkown_delegated_domains = []
+
     for hosted_zone in dsd_hosted_zones:
         for record_set in hosted_zone.record_sets:
             is_delegation = (
@@ -67,18 +72,22 @@ def main():
             if is_delegation:
                 found_delegation = False
                 total_delegations += 1
+                delegated_domains.append(record_set.name)
                 if __is_delegated_to_hosted_zones(dsd_hosted_zones, record_set):
                     internal_delgations_count += 1
+                    internal_delegated_domains.append(record_set.name)
                     found_delegation = True
 
                 if __is_delegated_to_hosted_zones(
                     cloud_platform_hosted_zones, record_set
                 ):
                     cloud_platform_delegations_count += 1
+                    cloud_platform_delegated_domains.append(record_set.name)
                     found_delegation = True
 
                 if not found_delegation:
                     unknown_delegations_count += 1
+                    unkown_delegated_domains.append(record_set.name)
 
     print(
         json.dumps(
@@ -88,7 +97,13 @@ def main():
                     "unknownDelegations": unknown_delegations_count,
                     "internalDelegations": internal_delgations_count,
                     "cloudPlatformDelegations": cloud_platform_delegations_count,
-                }
+                },
+                "delegations": {
+                    "all": delegated_domains,
+                    "cloudPlatform": cloud_platform_delegated_domains,
+                    "internal": internal_delegated_domains,
+                    "unkown": unkown_delegated_domains,
+                },
             }
         )
     )

--- a/services/route53_service.py
+++ b/services/route53_service.py
@@ -56,7 +56,12 @@ class Route53Service:
             record_set_type = record_set["Type"]
 
             record_values: list[RecordValueModel] = []
-            for record in record_set.get("ResourceRecords", []):
+            resource_records: list[dict[str, str]]
+            try:
+                resource_records = record_set["ResourceRecords"]
+            except KeyError:
+                resource_records = []
+            for record in resource_records:
                 record_values.append(RecordValueModel(value=record["Value"]))
 
             record_sets.append(

--- a/services/route53_service.py
+++ b/services/route53_service.py
@@ -3,8 +3,21 @@ import boto3
 
 
 @dataclass
+class RecordModel:
+    value: str
+
+
+@dataclass
+class RecordSetModel:
+    name: str
+    type: str
+    records: list[RecordModel]
+
+
+@dataclass
 class HostedZoneModel:
     name: str
+    record_sets: list[RecordSetModel]
 
 
 class Route53Service:
@@ -12,11 +25,39 @@ class Route53Service:
         session = boto3.Session(profile_name=profile)
         self.client = session.client("route53")
 
-    def get_route53_hosted_zones(self) -> list[HostedZoneModel]:
+    def __get_hosted_zone_record_sets(self, zone_id: str):
+        response = self.client.list_resource_record_sets(HostedZoneId=zone_id)
+
+        record_sets: list[RecordSetModel] = []
+        for record_set in response["ResourceRecordSets"]:
+            record_set_name = record_set["Name"]
+            record_set_type = record_set["Type"]
+
+            records: list[RecordModel] = []
+            for record in record_set.get("ResourceRecords", []):
+                records.append(RecordModel(value=record["Value"]))
+
+            record_sets.append(
+                RecordSetModel(
+                    name=record_set_name,
+                    type=record_set_type,
+                    records=records,
+                )
+            )
+
+        return record_sets
+
+    def get_hosted_zones(self) -> list[HostedZoneModel]:
         response = self.client.list_hosted_zones(MaxItems="1")
 
         hosted_zones: list[HostedZoneModel] = []
         for zone in response["HostedZones"]:
-            hosted_zones.append(HostedZoneModel(name=zone["Name"]))
-
+            zone_name = zone["Name"]
+            zone_id = zone["Id"]
+            hosted_zones.append(
+                HostedZoneModel(
+                    name=zone_name,
+                    record_sets=self.__get_hosted_zone_record_sets(zone_id),
+                )
+            )
         return hosted_zones

--- a/services/route53_service.py
+++ b/services/route53_service.py
@@ -3,7 +3,7 @@ import boto3
 
 
 @dataclass
-class RecordModel:
+class RecordValueModel:
     value: str
 
 
@@ -11,7 +11,7 @@ class RecordModel:
 class RecordSetModel:
     name: str
     type: str
-    records: list[RecordModel]
+    values: list[RecordValueModel]
 
 
 @dataclass
@@ -33,22 +33,22 @@ class Route53Service:
             record_set_name = record_set["Name"]
             record_set_type = record_set["Type"]
 
-            records: list[RecordModel] = []
+            record_values: list[RecordValueModel] = []
             for record in record_set.get("ResourceRecords", []):
-                records.append(RecordModel(value=record["Value"]))
+                record_values.append(RecordValueModel(value=record["Value"]))
 
             record_sets.append(
                 RecordSetModel(
                     name=record_set_name,
                     type=record_set_type,
-                    records=records,
+                    values=record_values,
                 )
             )
 
         return record_sets
 
     def get_hosted_zones(self) -> list[HostedZoneModel]:
-        response = self.client.list_hosted_zones(MaxItems="1")
+        response = self.client.list_hosted_zones(MaxItems="4")
 
         hosted_zones: list[HostedZoneModel] = []
         for zone in response["HostedZones"]:

--- a/services/route53_service.py
+++ b/services/route53_service.py
@@ -38,7 +38,7 @@ class Route53Service:
         paginator = self.client.get_paginator("list_hosted_zones")
         paginator_iterator = paginator.paginate(
             PaginationConfig={
-                "MaxItems": 4,
+                "MaxItems": 500,
             }
         )
 

--- a/services/route53_service.py
+++ b/services/route53_service.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import boto3
+
+
+@dataclass
+class HostedZoneModel:
+    name: str
+
+
+class Route53Service:
+    def __init__(self, profile: str) -> None:
+        session = boto3.Session(profile_name=profile)
+        self.client = session.client("route53")
+
+    def get_route53_hosted_zones(self) -> list[HostedZoneModel]:
+        response = self.client.list_hosted_zones(MaxItems="1")
+
+        hosted_zones: list[HostedZoneModel] = []
+        for zone in response["HostedZones"]:
+            hosted_zones.append(HostedZoneModel(name=zone["Name"]))
+
+        return hosted_zones

--- a/test/test_bin/test_dns_delegations_metrics.py
+++ b/test/test_bin/test_dns_delegations_metrics.py
@@ -1,0 +1,228 @@
+from typing import Any
+import unittest
+from unittest.mock import MagicMock, patch, Mock
+from bin.dns_delegations_metrics import main
+import json
+
+
+def mock_paginate(results: list[dict[str, Any]]):
+    return Mock(paginate=Mock(return_value=[Mock(get=Mock(return_value=results))]))
+
+
+def mock_boto3_session(side_effects: list):
+    return Mock(
+        client=Mock(
+            return_value=Mock(
+                get_paginator=Mock(
+                    side_effect=[
+                        mock_paginate(side_effect) for side_effect in side_effects
+                    ]
+                )
+            )
+        )
+    )
+
+
+class TestDnsDelegationsMetricsMain(unittest.TestCase):
+    @patch("services.route53_service.boto3")
+    @patch("bin.dns_delegations_metrics.logging")
+    def test_logs_logs_no_delegations_when_no_hosted_zones_returned(
+        self, mock_logging: MagicMock, mock_boto3: MagicMock
+    ):
+        mock_boto3.Session.return_value = MagicMock()
+        main()
+        mock_logging.info.assert_called_with(json.dumps({"delegations": []}))
+
+    @patch("services.route53_service.boto3")
+    @patch("bin.dns_delegations_metrics.logging")
+    def test_logs_delegations_that_cannot_be_matched_as_unknown(
+        self, mock_logging: MagicMock, mock_boto3: MagicMock
+    ):
+        mock_dsd_hosted_zones = [{"Name": "justice.gov.uk", "Id": "1"}]
+        mock_dsd_records = [{"Name": "test.justice.gov.uk", "Type": "NS"}]
+        mock_cp_hosted_zones = [{"Name": "cp.justice.gov.uk", "Id": "2"}]
+        mock_cp_records = [{"Name": "test.cp.justice.gov.uk", "Type": "TXT"}]
+        mock_boto3.Session.return_value = mock_boto3_session(
+            [
+                mock_dsd_hosted_zones,
+                mock_dsd_records,
+                mock_cp_hosted_zones,
+                mock_cp_records,
+            ]
+        )
+        main()
+        mock_logging.info.assert_called_with(
+            json.dumps(
+                {
+                    "delegations": [
+                        {
+                            "type": "ACCOUNT",
+                            "name": "DSD",
+                            "totals": {
+                                "all": [1, "100%"],
+                                "to_unknown": [1, "100%"],
+                                "to_cloud_platform": [0, "0%"],
+                                "to_dsd": [0, "0%"],
+                            },
+                            "all": ["test.justice.gov.uk"],
+                            "to_unknown": ["test.justice.gov.uk"],
+                            "to_cloud_platform": [],
+                            "to_dsd": [],
+                        },
+                        {
+                            "type": "HOSTED_ZONES",
+                            "name": "DSD - justice.gov.uk",
+                            "totals": {
+                                "all": [1, "100%"],
+                                "to_unknown": [1, "100%"],
+                                "to_cloud_platform": [0, "0%"],
+                                "to_dsd": [0, "0%"],
+                            },
+                            "all": ["test.justice.gov.uk"],
+                            "to_unknown": ["test.justice.gov.uk"],
+                            "to_cloud_platform": [],
+                            "to_dsd": [],
+                        },
+                    ]
+                }
+            )
+        )
+
+    @patch("services.route53_service.boto3")
+    @patch("bin.dns_delegations_metrics.logging")
+    def test_logs_delegations_to_cloud_platform(
+        self, mock_logging: MagicMock, mock_boto3: MagicMock
+    ):
+        mock_dsd_hosted_zones = [{"Name": "justice.gov.uk", "Id": "1"}]
+        mock_dsd_records = [
+            {
+                "Name": "cp.justice.gov.uk",
+                "Type": "NS",
+                "ResourceRecords": [{"Value": "ns-1.com"}],
+            }
+        ]
+        mock_cp_hosted_zones = [{"Name": "cp.justice.gov.uk", "Id": "2"}]
+        mock_cp_records = [
+            {
+                "Name": "cp.justice.gov.uk",
+                "Type": "NS",
+                "ResourceRecords": [{"Value": "ns-1.com"}],
+            }
+        ]
+        mock_boto3.Session.return_value = mock_boto3_session(
+            [
+                mock_dsd_hosted_zones,
+                mock_dsd_records,
+                mock_cp_hosted_zones,
+                mock_cp_records,
+            ]
+        )
+        main()
+        mock_logging.info.assert_called_with(
+            json.dumps(
+                {
+                    "delegations": [
+                        {
+                            "type": "ACCOUNT",
+                            "name": "DSD",
+                            "totals": {
+                                "all": [1, "100%"],
+                                "to_unknown": [0, "0%"],
+                                "to_cloud_platform": [1, "100%"],
+                                "to_dsd": [0, "0%"],
+                            },
+                            "all": ["cp.justice.gov.uk"],
+                            "to_unknown": [],
+                            "to_cloud_platform": ["cp.justice.gov.uk"],
+                            "to_dsd": [],
+                        },
+                        {
+                            "type": "HOSTED_ZONES",
+                            "name": "DSD - justice.gov.uk",
+                            "totals": {
+                                "all": [1, "100%"],
+                                "to_unknown": [0, "0%"],
+                                "to_cloud_platform": [1, "100%"],
+                                "to_dsd": [0, "0%"],
+                            },
+                            "all": ["cp.justice.gov.uk"],
+                            "to_unknown": [],
+                            "to_cloud_platform": ["cp.justice.gov.uk"],
+                            "to_dsd": [],
+                        },
+                    ]
+                }
+            )
+        )
+
+    @patch("services.route53_service.boto3")
+    @patch("bin.dns_delegations_metrics.logging")
+    def test_logs_delegations_to_dsd(
+        self, mock_logging: MagicMock, mock_boto3: MagicMock
+    ):
+        mock_dsd_hosted_zones = [
+            {"Name": "justice.gov.uk", "Id": "1"},
+            {"Name": "local.justice.gov.uk", "Id": "2"},
+        ]
+        mock_dsd_justice_records = [
+            {
+                "Name": "local.justice.gov.uk",
+                "Type": "NS",
+                "ResourceRecords": [{"Value": "ns-1.com"}],
+            },
+        ]
+        mock_dsd_local_justice_records = [
+            {
+                "Name": "local.justice.gov.uk",
+                "Type": "NS",
+                "ResourceRecords": [{"Value": "ns-1.com"}],
+            },
+        ]
+        mock_cp_hosted_zones = []
+        mock_cp_records = []
+        mock_boto3.Session.return_value = mock_boto3_session(
+            [
+                mock_dsd_hosted_zones,
+                mock_dsd_justice_records,
+                mock_dsd_local_justice_records,
+                mock_cp_hosted_zones,
+                mock_cp_records,
+            ]
+        )
+        main()
+        mock_logging.info.assert_called_with(
+            json.dumps(
+                {
+                    "delegations": [
+                        {
+                            "type": "ACCOUNT",
+                            "name": "DSD",
+                            "totals": {
+                                "all": [1, "100%"],
+                                "to_unknown": [0, "0%"],
+                                "to_cloud_platform": [0, "0%"],
+                                "to_dsd": [1, "100%"],
+                            },
+                            "all": ["local.justice.gov.uk"],
+                            "to_unknown": [],
+                            "to_cloud_platform": [],
+                            "to_dsd": ["local.justice.gov.uk"],
+                        },
+                        {
+                            "type": "HOSTED_ZONES",
+                            "name": "DSD - justice.gov.uk",
+                            "totals": {
+                                "all": [1, "100%"],
+                                "to_unknown": [0, "0%"],
+                                "to_cloud_platform": [0, "0%"],
+                                "to_dsd": [1, "100%"],
+                            },
+                            "all": ["local.justice.gov.uk"],
+                            "to_unknown": [],
+                            "to_cloud_platform": [],
+                            "to_dsd": ["local.justice.gov.uk"],
+                        },
+                    ]
+                }
+            )
+        )

--- a/test/test_bin/test_dns_delegations_metrics.py
+++ b/test/test_bin/test_dns_delegations_metrics.py
@@ -23,9 +23,9 @@ def mock_boto3_session(side_effects: list):
     )
 
 
+@patch("services.route53_service.boto3")
+@patch("bin.dns_delegations_metrics.logging")
 class TestDnsDelegationsMetricsMain(unittest.TestCase):
-    @patch("services.route53_service.boto3")
-    @patch("bin.dns_delegations_metrics.logging")
     def test_logs_logs_no_delegations_when_no_hosted_zones_returned(
         self, mock_logging: MagicMock, mock_boto3: MagicMock
     ):
@@ -33,8 +33,6 @@ class TestDnsDelegationsMetricsMain(unittest.TestCase):
         main()
         mock_logging.info.assert_called_with(json.dumps({"delegations": []}))
 
-    @patch("services.route53_service.boto3")
-    @patch("bin.dns_delegations_metrics.logging")
     def test_logs_delegations_that_cannot_be_matched_as_unknown(
         self, mock_logging: MagicMock, mock_boto3: MagicMock
     ):
@@ -88,8 +86,6 @@ class TestDnsDelegationsMetricsMain(unittest.TestCase):
             )
         )
 
-    @patch("services.route53_service.boto3")
-    @patch("bin.dns_delegations_metrics.logging")
     def test_logs_delegations_to_cloud_platform(
         self, mock_logging: MagicMock, mock_boto3: MagicMock
     ):
@@ -155,8 +151,6 @@ class TestDnsDelegationsMetricsMain(unittest.TestCase):
             )
         )
 
-    @patch("services.route53_service.boto3")
-    @patch("bin.dns_delegations_metrics.logging")
     def test_logs_delegations_to_dsd(
         self, mock_logging: MagicMock, mock_boto3: MagicMock
     ):


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4653
- To enable automated metric gathering of DNS Delegations

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added a script to gather metrics about DNS Delegations

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- I realise that most Route53 functionality has been migrated to the [https://github.com/ministryofjustice/dns](https://github.com/ministryofjustice/dns) repository - although with this being experimental (and potentially going to make use of the KPI Service) - I thought it best not to add a bunch of experimental code to the DNS repository

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
