### PR TITLE
Remove encryption-key which cannot be empty for apply to create

### DIFF
--- a/terraform/auth0/operations-engineering/clients.tf
+++ b/terraform/auth0/operations-engineering/clients.tf
@@ -572,7 +572,6 @@ resource "auth0_client" "operations_engineering_kpi_dashboard" {
   custom_login_page                     = null
   custom_login_page_on                  = true
   description                           = null
-  encryption_key                        = {}
   form_template                         = null
   grant_types                           = ["authorization_code", "implicit", "refresh_token"]
   initiate_login_uri                    = null


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose
• Remove `encryption-key` which cannot be empty for apply to create

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed
•  deleted `encryption-key = {}` 

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes
• [See here for another instance](https://github.com/auth0/terraform-provider-auth0/issues/909)
• `encryption-key = {}` exists in the other resources as these were generated from existing resources, they have never been created in an apply by `terraform`. However, for a creation apply `encryption-key` cannot be empty.

wrt FIREBREAK: 🔥 Get KPI Dashboard Production Ready [#4612](https://github.com/ministryofjustice/operations-engineering/issues/4612)

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
