### PR TITLE
Ensure new head of hosting doesn't generate alerts

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -7,6 +7,7 @@ ENTERPRISE = "ministry-of-justice-uk"
 SLACK_CHANNEL = "operations-engineering-alerts"
 SR_SLACK_CHANNEL = "operations-engineering-team"
 OPERATIONS_ENGINEERING_GITHUB_USERNAMES = [
+    "SeanPrivett",
     "SteveMarshall",
     "andyrogers1973",
     "jasonBirchall",
@@ -15,6 +16,5 @@ OPERATIONS_ENGINEERING_GITHUB_USERNAMES = [
     "connormaglynn",
     "PepperMoJ",
     "levgorbunov1",
-    "vijaykannan21",
     "moj-operations-engineering-bot",
 ]


### PR DESCRIPTION
## :eyes: Purpose
Sean is taking over as head of hosting, so will be getting access to various things. We don't want to alert about his presence, so this adds him to the list of people who should have access.

This also removes Vijay, who left us a short while back.

### :white_check_mark: Things to Check (Optional)
- 🚫 ~I have run all unit tests, and they pass~
- 🚫 ~I have ensured my code follows the project's coding standards~
- 🚫 ~I have checked that all new dependencies are up to date and necessary~

I have done none of these things, sorry!
