### PR TITLE
♻️ Change the slack message to improve readability

### DIFF
--- a/bin/identify_dormant_github_users.py
+++ b/bin/identify_dormant_github_users.py
@@ -146,7 +146,7 @@ def message_to_slack_channel(dormant_users: list) -> str:
     )
 
     for user in dormant_users:
-        msg += f"GitHub username: {user.name} | Email: {user.email}\n"
+        msg += f"{user.name} | {user.email}\n"
 
     return msg
 

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -50,8 +50,8 @@ class TestDormantGitHubUsers(unittest.TestCase):
         expected_message = (
             "Hello 🤖, \n\n"
             "Here is a list of dormant GitHub users that have not been seen in Auth0 logs:\n\n"
-            "GitHub username: user1 | Email: user1@example.com\n"
-            "GitHub username: user2 | Email: user2@example.com\n"
+            "user1 | user1@example.com\n"
+            "user2 | user2@example.com\n"
         )
 
         self.assertEqual(result, expected_message)


### PR DESCRIPTION
When the dormant user count exceeds ten users, the slack message becomes extremely difficult to read.

Here is an example of the hard to read slack message:
https://mojdt.slack.com/archives/C033QBE511V/p1725378457120739
