### PR TITLE
:sparkles: Add a Flask template repository to increase velocity

### DIFF
--- a/terraform/github/repositories/ministryofjustice/operations-engineering-flask-template.tf
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-flask-template.tf
@@ -1,0 +1,13 @@
+module "operations-engineering-flask-template" {
+  source  = "ministryofjustice/repository/github"
+  version = "1.1.2"
+
+  name        = "operations-engineering-flask-template"
+  type        = "template"
+  description = "Template repository containing a Flask application used by the Operations Engineering team."
+  topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [var.operations_engineering_team_id]
+  }
+}


### PR DESCRIPTION
The idea behind this is to allow the Operations Engineering team to quickly create applications based on a tried and trusted Flask template. All of our Flask applications (join/dns-form, etc) appear identical in several areas. By creating a boilerplate template, we should improve velocity and standardise best practices.
