### PR TITLE
:sparkles: Add new repository to hold a cloud platform tf module

### DIFF
--- a/terraform/github/repositories/ministryofjustice/operations-engineering-cloud-platform-namespace.tf
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-cloud-platform-namespace.tf
@@ -3,7 +3,7 @@ module "operations-engineering-cloud-platform-namespace" {
   version = "1.1.2"
 
   name        = "operations-engineering-cloud-platform-namespace"
-  description = "This reoisitory contains the terraform code for an operations engineering namespace in the cloud platform"
+  description = "This repository contains the terraform code for an operations engineering namespace in the cloud platform"
   topics      = ["operations-engineering"]
 
   team_access = {

--- a/terraform/github/repositories/ministryofjustice/operations-engineering-cloud-platform-namespace.tf
+++ b/terraform/github/repositories/ministryofjustice/operations-engineering-cloud-platform-namespace.tf
@@ -1,0 +1,12 @@
+module "operations-engineering-cloud-platform-namespace" {
+  source  = "ministryofjustice/repository/github"
+  version = "1.1.2"
+
+  name        = "operations-engineering-cloud-platform-namespace"
+  description = "This reoisitory contains the terraform code for an operations engineering namespace in the cloud platform"
+  topics      = ["operations-engineering"]
+
+  team_access = {
+    admin = [var.operations_engineering_team_id]
+  }
+}


### PR DESCRIPTION
The module will allow operations engineering the ability to quickly create a cloud platform namespace.
