### PR TITLE
:sparkles: Add dns-form-dev auth0 client

### DIFF
--- a/terraform/auth0/operations-engineering/clients.tf
+++ b/terraform/auth0/operations-engineering/clients.tf
@@ -338,7 +338,7 @@ resource "auth0_client" "dns_form_dev" {
   cross_origin_loc                      = null
   custom_login_page                     = null
   custom_login_page_on                  = true
-  description                           = "This enables Microsoft and Google authentication to the DNS Form currently in Dev: https://dns-form-dev.cloud-platform.service.justice.gov.uk/."
+  description                           = "This enables authentication to the DNS Form currently in Dev"
   form_template                         = null
   grant_types                           = ["authorization_code", "implicit", "refresh_token", "client_credentials"]
   initiate_login_uri                    = null

--- a/terraform/auth0/operations-engineering/clients.tf
+++ b/terraform/auth0/operations-engineering/clients.tf
@@ -326,6 +326,59 @@ resource "auth0_client" "kpi_dashboard" {
   }
 }
 
+resource "auth0_client" "dns_form_dev" {
+  allowed_clients                       = []
+  allowed_logout_urls                   = ["http://127.0.0.1:4567", "http://127.0.0.1/", "http://localhost:4567", "http://localhost", "http://0.0.0.0", "https://dns-form-dev.cloud-platform.service.justice.gov.uk/", "http://dns-form-dev.cloud-platform.service.justice.gov.uk/"]
+  allowed_origins                       = []
+  app_type                              = "regular_web"
+  callbacks                             = ["https://localhost:4567/auth/callback", "http://127.0.0.1:4567/auth/callback", "http://127.0.0.1/auth/callback", "http://localhost:4567/auth/callback", "http://0.0.0.0:4567/auth/callback", "http://localhost/auth/callback", "https://dns-form-dev.cloud-platform.service.justice.gov.uk/auth/callback", "http://dns-form-dev.cloud-platform.service.justice.gov.uk/auth/callback"]
+  client_aliases                        = []
+  client_metadata                       = {}
+  cross_origin_auth                     = false
+  cross_origin_loc                      = null
+  custom_login_page                     = null
+  custom_login_page_on                  = true
+  description                           = "This enables Microsoft and Google authentication to the DNS Form currently in Dev: https://dns-form-dev.cloud-platform.service.justice.gov.uk/."
+  form_template                         = null
+  grant_types                           = ["authorization_code", "implicit", "refresh_token", "client_credentials"]
+  initiate_login_uri                    = null
+  is_first_party                        = true
+  is_token_endpoint_ip_header_trusted   = false
+  logo_uri                              = null
+  name                                  = "DNS Form Dev"
+  oidc_backchannel_logout_urls          = []
+  oidc_conformant                       = true
+  organization_require_behavior         = "no_prompt"
+  organization_usage                    = null
+  require_pushed_authorization_requests = false
+  sso                                   = false
+  sso_disabled                          = false
+  web_origins                           = ["http://127.0.0.1:4567", "http://localhost:4567", "http://localhost", "http://127.0.0.1/", "http://0.0.0.0:4567", "https://dns-form-dev.cloud-platform.service.justice.gov.uk/"]
+  jwt_configuration {
+    alg                 = "RS256"
+    lifetime_in_seconds = 35994
+    scopes              = {}
+    secret_encoded      = false
+  }
+  native_social_login {
+    apple {
+      enabled = false
+    }
+    facebook {
+      enabled = false
+    }
+  }
+  refresh_token {
+    expiration_type              = "non-expiring"
+    idle_token_lifetime          = 2592000
+    infinite_idle_token_lifetime = true
+    infinite_token_lifetime      = true
+    leeway                       = 0
+    rotation_type                = "non-rotating"
+    token_lifetime               = 31557600
+  }
+}
+
 resource "auth0_client" "join_github_dev" {
   allowed_clients                       = []
   allowed_logout_urls                   = ["http://127.0.0.1:4567", "http://127.0.0.1/", "http://localhost:4567", "http://localhost", "http://0.0.0.0", "https://dev.join-github.service.justice.gov.uk/", "http://dev.join-github.service.justice.gov.uk/"]


### PR DESCRIPTION
This allows us to make auth0 calls from the dev dns form. It connects to https://github.com/ministryofjustice/operations-engineering/issues/4839
