### PR TITLE
:sparkles: Add new client details for a change-dns production

### DIFF
--- a/terraform/auth0/operations-engineering/clients.tf
+++ b/terraform/auth0/operations-engineering/clients.tf
@@ -379,6 +379,59 @@ resource "auth0_client" "dns_form_dev" {
   }
 }
 
+resource "auth0_client" "dns_form_prod" {
+  allowed_clients                       = []
+  allowed_logout_urls                   = ["http://127.0.0.1:4567", "http://127.0.0.1/", "http://localhost:4567", "http://localhost", "http://0.0.0.0", "https://change-dns.service.justice.gov.uk/", "http://change-dns.service.justice.gov.uk/"]
+  allowed_origins                       = []
+  app_type                              = "regular_web"
+  callbacks                             = ["https://localhost:4567/auth/callback", "http://127.0.0.1:4567/auth/callback", "http://127.0.0.1/auth/callback", "http://localhost:4567/auth/callback", "http://0.0.0.0:4567/auth/callback", "http://localhost/auth/callback", "https://change-dns.service.justice.gov.uk/auth/callback", "http://change-dns.service.justice.gov.uk/auth/callback"]
+  client_aliases                        = []
+  client_metadata                       = {}
+  cross_origin_auth                     = false
+  cross_origin_loc                      = null
+  custom_login_page                     = null
+  custom_login_page_on                  = true
+  description                           = "This enables authentication to the DNS Form"
+  form_template                         = null
+  grant_types                           = ["authorization_code", "implicit", "refresh_token", "client_credentials"]
+  initiate_login_uri                    = null
+  is_first_party                        = true
+  is_token_endpoint_ip_header_trusted   = false
+  logo_uri                              = null
+  name                                  = "DNS Form Prod"
+  oidc_backchannel_logout_urls          = []
+  oidc_conformant                       = true
+  organization_require_behavior         = "no_prompt"
+  organization_usage                    = null
+  require_pushed_authorization_requests = false
+  sso                                   = false
+  sso_disabled                          = false
+  web_origins                           = ["http://127.0.0.1:4567", "http://localhost:4567", "http://localhost", "http://127.0.0.1/", "http://0.0.0.0:4567", "https://change-dns.service.justice.gov.uk/"]
+  jwt_configuration {
+    alg                 = "RS256"
+    lifetime_in_seconds = 35994
+    scopes              = {}
+    secret_encoded      = false
+  }
+  native_social_login {
+    apple {
+      enabled = false
+    }
+    facebook {
+      enabled = false
+    }
+  }
+  refresh_token {
+    expiration_type              = "non-expiring"
+    idle_token_lifetime          = 2592000
+    infinite_idle_token_lifetime = true
+    infinite_token_lifetime      = true
+    leeway                       = 0
+    rotation_type                = "non-rotating"
+    token_lifetime               = 31557600
+  }
+}
+
 resource "auth0_client" "github" {
   allowed_clients                       = []
   allowed_logout_urls                   = []


### PR DESCRIPTION
This pull request adds a new Auth0 client configuration for the production environment in the `terraform/auth0/operations-engineering/clients.tf` file. The new configuration includes various settings such as allowed URLs, grant types, and JWT configuration.

New Auth0 client configuration:

* Added `resource "auth0_client" "dns_form_prod"` with settings including `allowed_logout_urls`, `callbacks`, `grant_types`, and `jwt_configuration`.