### PR TITLE
:recycle: Reword the description of github-actions

### DIFF
--- a/terraform/github/repositories/ministryofjustice/github-actions.tf
+++ b/terraform/github/repositories/ministryofjustice/github-actions.tf
@@ -5,7 +5,7 @@ module "github-actions" {
   poc = false
 
   name        = "github-actions"
-  description = "A github action which will run code formatters against PRs, and commit any resulting changes"
+  description = "A collection of reusable GitHub Actions for the Ministry of Justice, designed to streamline and enhance workflows across our projects."
   topics      = ["operations-engineering"]
 
   team_access = {


### PR DESCRIPTION
This pull request updates the description of the GitHub Actions module in the `terraform/github/repositories/ministryofjustice/github-actions.tf` file to better reflect its purpose and usage.

* [`terraform/github/repositories/ministryofjustice/github-actions.tf`](diffhunk://#diff-edeb272f5377159c99fa3e1e05aa66b8da825b3a69061e7a296e335801ffd688L8-R8): Updated the description to "A collection of reusable GitHub Actions for the Ministry of Justice, designed to streamline and enhance workflows across our projects."