### PR TITLE
🔧 Fix `Generate GitHub Standards Report` Workflow Failing

### DIFF
--- a/.github/workflows/job-generate-github-standards-report.yaml
+++ b/.github/workflows/job-generate-github-standards-report.yaml
@@ -2,7 +2,7 @@ name: 🤖 Generate GitHub Standards Report
 
 on:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 jobs:

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -13,7 +13,7 @@ from github.Organization import Organization
 from github.Repository import Repository
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
-from gql.transport.exceptions import TransportQueryError
+from gql.transport.exceptions import TransportServerError
 from requests import Session
 
 from config.logging_config import logging
@@ -37,7 +37,7 @@ def retries_github_rate_limit_exception_at_next_reset_once(func: Callable) -> Ca
         """
         try:
             return func(*args, **kwargs)
-        except (RateLimitExceededException, TransportQueryError) as exception:
+        except (RateLimitExceededException, TransportServerError) as exception:
             logging.warning(
                 f"Caught {type(exception).__name__}, retrying calls when rate limit resets.")
             rate_limits = args[0].github_client_core_api.get_rate_limit()

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -12,7 +12,7 @@ from github.NamedUser import NamedUser
 from github.Organization import Organization
 from github.Repository import Repository
 from github.Variable import Variable
-from gql.transport.exceptions import TransportQueryError
+from gql.transport.exceptions import TransportServerError
 
 from services.github_service import (
     GithubService, retries_github_rate_limit_exception_at_next_reset_once)
@@ -65,9 +65,9 @@ class TestRetriesGithubRateLimitExceptionAtNextResetOnce(unittest.TestCase):
                           "test_arg")
 
     @freeze_time("2023-02-01")
-    def test_function_is_called_twice_when_transport_query_error_raised_once(self):
+    def test_function_is_called_twice_when_transport_server_error_raised_once(self):
         mock_function = Mock(
-            side_effect=[TransportQueryError(Mock(), Mock(), Mock()), Mock()])
+            side_effect=[TransportServerError(Mock(), Mock()), Mock()])
         mock_github_client = Mock(Github)
         mock_github_client.get_rate_limit().graphql.reset = datetime.now()
         mock_github_service = Mock(
@@ -79,14 +79,14 @@ class TestRetriesGithubRateLimitExceptionAtNextResetOnce(unittest.TestCase):
     @freeze_time("2023-02-01")
     def test_rate_limit_exception_raised_when_transport_query_error_raised_twice(self):
         mock_function = Mock(side_effect=[
-            TransportQueryError(Mock(), Mock(), Mock()),
-            TransportQueryError(Mock(), Mock(), Mock())]
+            TransportServerError(Mock(), Mock()),
+            TransportServerError(Mock(), Mock())]
         )
         mock_github_client = Mock(Github)
         mock_github_client.get_rate_limit().graphql.reset = datetime.now()
         mock_github_service = Mock(
             GithubService, github_client_core_api=mock_github_client)
-        self.assertRaises(TransportQueryError,
+        self.assertRaises(TransportServerError,
                           retries_github_rate_limit_exception_at_next_reset_once(
                               mock_function), mock_github_service,
                           "test_arg")


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4962
- To fix `Generate GitHub Standards Report` job failing intermittently 

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Moved the Cron Schedule back 2 hours, we have a couple of other jobs that run at 4:00am that also use the same token - with this one being a heavier process so will generally be the one hitting the limit
- Fixed an error with the retry logic where were catching `TransportQueryError` - this is used when there is an issue with the query i.e. syntax. We now catch `TransportServerError` which was the exception being raised in the case of the failing workflow. The response status was 403, which lines up as to what we expect with a rate limiting issue.

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)
- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
