### PR TITLE
🔧 Fix Standards Reports Failing by Reducing Batch Size

### DIFF
--- a/services/operations_engineering_reports.py
+++ b/services/operations_engineering_reports.py
@@ -41,10 +41,10 @@ class OperationsEngineeringReportsService:
             Exception: If the status code of the POST request is not 200.
 
         """
-        #  Batched into groups of 100 due to database limitations
+        #  Batched into groups of 10 due to database limitations
         self.logger.info("Sending %s repository standards reports to API.", len(reports))
-        for i in range(0, len(reports), 100):
-            chunk = reports[i: i + 100]
+        for i in range(0, len(reports), 10):
+            chunk = reports[i: i + 10]
             status = self.__http_post(chunk)
             if status != 200:
                 self.logger.error("Failed to send chunk starting from index %s. Received status: %s", i, status)


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

- To fix the standards report failing by reducing batch size on post requests ([example failure](https://github.com/ministryofjustice/operations-engineering/actions/runs/11905041025/job/33174847257))

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Reduced the batch size from 100 to 10

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- From looking at the server logs on the reports app, DynamoDB starts to slow down it's response, with the slowest responses being around 3 seconds. With a batch size of 100, you would need a timeout of ~300 seconds to handle a rate-limited batch. Reducing the batch size to 10 means a request can be handled with a timeout of ~30 seconds. The reports app is currently set to 120 seconds before a timeout, which explains why a batch size of 100 fails when DynamoDB starts to rate-limit requests. A batch size of 10 should be small enough to ensure requests are complete, even with excessive rate-limiting from DynamoDB

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)

- [ ] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
