### PR TITLE
Replace single token with one per org

### DIFF
--- a/.github/workflows/job-identify-dormant-github-users-v2.yml
+++ b/.github/workflows/job-identify-dormant-github-users-v2.yml
@@ -52,6 +52,7 @@ jobs:
 
       - run: pipenv run python3 -m bin.identify_dormant_github_users_v2
         env:
-          GH_ADMIN_TOKEN: ${{ secrets.DORMANT_USERS_TEST_MULTIORG_ADMIN_GH_TOKEN }}
+          GH_MOJ_TOKEN: ${{ secrets.GH_MOJ_DORMANT_USERS_READ }}
+          GH_MOJAS_TOKEN: ${{ secrets.GH_MOJAS_DORMANT_USERS_READ }}
           ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
           USE_MP_INFRASTRUCTURE: ${{ inputs.use_modernisation_platform_infrastructure }}

--- a/bin/identify_dormant_github_users_v2.py
+++ b/bin/identify_dormant_github_users_v2.py
@@ -113,15 +113,15 @@ def map_usernames_to_emails(users, moj_github_org: GithubService, ap_github_org:
 
 
 def identify_dormant_github_users():
-    env = EnvironmentVariables(["GH_ADMIN_TOKEN", "ADMIN_SLACK_TOKEN", "USE_MP_INFRASTRUCTURE"])
+    env = EnvironmentVariables(["GH_MOJ_TOKEN", "GH_MOJAS_TOKEN", "ADMIN_SLACK_TOKEN", "USE_MP_INFRASTRUCTURE"])
     use_moderation_platform_infrastructure = env.get("USE_MP_INFRASTRUCTURE") == "true"
 
     print("Using moderation platform infrastructure:", use_moderation_platform_infrastructure)
     print("Env var valaue USE_MP_INFRASTRUCTURE:", env.get("USE_MP_INFRASTRUCTURE"))
 
     gh_orgs = [
-        GithubService(env.get("GH_ADMIN_TOKEN"), MINISTRY_OF_JUSTICE),
-        GithubService(env.get("GH_ADMIN_TOKEN"), MOJ_ANALYTICAL_SERVICES)
+        GithubService(env.get("GH_MOJ_TOKEN"), MINISTRY_OF_JUSTICE),
+        GithubService(env.get("GH_MOJAS_TOKEN"), MOJ_ANALYTICAL_SERVICES)
     ]
 
     dormant_users_according_to_github = get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(gh_orgs[0], ALLOWED_BOT_USERS, use_moderation_platform_infrastructure)

--- a/bin/identify_dormant_github_users_v2.py
+++ b/bin/identify_dormant_github_users_v2.py
@@ -44,11 +44,11 @@ class DormantUser:
     email: str | None
 
 
-def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_service, bot_list: list, use_moderation_platform_infrastructure: bool) -> list:
+def get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(github_service, bot_list: list, use_modernisation_platform_infrastructure: bool) -> list:
     all_users = github_service.get_all_enterprise_members()
 
-    cloudtrail_service = CloudtrailService(use_moderation_platform_infrastructure)
-    active_users = cloudtrail_service.get_active_users_for_dormant_users_process(use_moderation_platform_infrastructure)
+    cloudtrail_service = CloudtrailService(use_modernisation_platform_infrastructure)
+    active_users = cloudtrail_service.get_active_users_for_dormant_users_process(use_modernisation_platform_infrastructure)
 
     return [user for user in all_users if user not in list(set(active_users).union(bot_list))]
 
@@ -114,9 +114,9 @@ def map_usernames_to_emails(users, moj_github_org: GithubService, ap_github_org:
 
 def identify_dormant_github_users():
     env = EnvironmentVariables(["GH_MOJ_TOKEN", "GH_MOJAS_TOKEN", "ADMIN_SLACK_TOKEN", "USE_MP_INFRASTRUCTURE"])
-    use_moderation_platform_infrastructure = env.get("USE_MP_INFRASTRUCTURE") == "true"
+    use_modernisation_platform_infrastructure = env.get("USE_MP_INFRASTRUCTURE") != "false"
 
-    print("Using moderation platform infrastructure:", use_moderation_platform_infrastructure)
+    print("Using moderation platform infrastructure:", use_modernisation_platform_infrastructure)
     print("Env var valaue USE_MP_INFRASTRUCTURE:", env.get("USE_MP_INFRASTRUCTURE"))
 
     gh_orgs = [
@@ -124,7 +124,7 @@ def identify_dormant_github_users():
         GithubService(env.get("GH_MOJAS_TOKEN"), MOJ_ANALYTICAL_SERVICES)
     ]
 
-    dormant_users_according_to_github = get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(gh_orgs[0], ALLOWED_BOT_USERS, use_moderation_platform_infrastructure)
+    dormant_users_according_to_github = get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(gh_orgs[0], ALLOWED_BOT_USERS, use_modernisation_platform_infrastructure)
 
     dormant_users_with_emails = map_usernames_to_emails(dormant_users_according_to_github, gh_orgs[0], gh_orgs[1])
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1325,6 +1325,8 @@ class GithubService:
                         current_logins=logins
                     )
                 )
+                rate_limits = self.github_client_core_api.get_rate_limit()
+                logging.info(f"Current core rate limit: {rate_limits}")
             for future in concurrent.futures.as_completed(futures):
                 if future.result():
                     active_repos_and_current_contributors.append(future.result())
@@ -1386,6 +1388,8 @@ class GithubService:
         logging.info(
             f"Getting paginated list of org unlocked unarchived repositories. Page size {page_size}, after cursor {bool(after_cursor)}"
         )
+        rate_limits = self.github_client_core_api.get_rate_limit()
+        logging.info(f"Current core rate limit: {rate_limits}")
         if page_size > self.GITHUB_GQL_MAX_PAGE_SIZE:
             raise ValueError(
                 f"Page size of {page_size} is too large. Max page size {self.GITHUB_GQL_MAX_PAGE_SIZE}")

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1308,11 +1308,13 @@ class GithubService:
         logins = [user.login for user in self.__get_all_users()]
         active_repos = self.get_active_repositories()
         number_of_repos = len(active_repos)
-        print(f"Org: {self.organisation_name} has {len(logins)} members and {number_of_repos} active repositories")
+        logging.info(
+            f"Org: {self.organisation_name} has {len(logins)} members and {number_of_repos} active repositories"
+        )
 
         active_repos_and_current_contributors = []
 
-        print(f"Getting current contributors for active repos in {self.organisation_name}")
+        logging.info(f"Getting current contributors for active repos in {self.organisation_name}")
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []
             for repo_name in active_repos:

--- a/test/test_bin/test_identify_dormant_github_users.py
+++ b/test/test_bin/test_identify_dormant_github_users.py
@@ -27,7 +27,7 @@ class TestDormantGitHubUsers(unittest.TestCase):
     @patch('bin.identify_dormant_github_users_v2.get_inactive_users_from_data_lake_ignoring_bots_and_collaborators')
     @patch('os.environ')
     def test_identify_dormant_github_users(self, mock_env, _mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators, mock_map_usernames_to_emails, mock_filter_out_active_auth0_users, mock_filter_out_inactive_committers, _mock_github_client_core_api):
-        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_ADMIN_TOKEN', 'ADMIN_SLACK_TOKEN', 'USE_MP_INFRASTRUCTURE'] else None
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN', 'USE_MP_INFRASTRUCTURE'] else None
         mock_map_usernames_to_emails.return_value = [{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}]
         mock_filter_out_active_auth0_users.return_value = ["user1", "user2"]
 

--- a/test/test_utils/test_environment.py
+++ b/test/test_utils/test_environment.py
@@ -6,28 +6,30 @@ from utils.environment import EnvironmentVariables
 
 class TestEnvironmentVariables(unittest.TestCase):
 
-    @patch.dict('os.environ', {'GH_ADMIN_TOKEN': 'fake_github_token', 'ADMIN_SLACK_TOKEN': 'fake_slack_token'})
+    @patch.dict('os.environ', {'GH_MOJ_TOKEN': 'fake_moj_github_token', 'GH_MOJAS_TOKEN': 'fake_mojas_github_token', 'ADMIN_SLACK_TOKEN': 'fake_slack_token'})
     def test_all_env_vars_set(self):
         env_vars = EnvironmentVariables(
-            ['GH_ADMIN_TOKEN', 'ADMIN_SLACK_TOKEN'])
-        self.assertEqual(env_vars.get('GH_ADMIN_TOKEN'), 'fake_github_token')
+            ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'])
+        self.assertEqual(env_vars.get('GH_MOJ_TOKEN'), 'fake_moj_github_token')
+        self.assertEqual(env_vars.get('GH_MOJAS_TOKEN'), 'fake_mojas_github_token')
         self.assertEqual(env_vars.get('ADMIN_SLACK_TOKEN'), 'fake_slack_token')
 
     @patch.dict('os.environ', {})
     def test_missing_env_vars(self):
         with self.assertRaises(EnvironmentError):
-            EnvironmentVariables(['GH_ADMIN_TOKEN', 'ADMIN_SLACK_TOKEN'])
+            EnvironmentVariables(['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'])
 
-    @patch.dict('os.environ', {'GH_ADMIN_TOKEN': 'fake_github_token'})
+    @patch.dict('os.environ', {'GH_MOJ_TOKEN': 'fake_moj_github_token'})
     def test_partial_env_vars_set(self):
         with self.assertRaises(EnvironmentError):
-            EnvironmentVariables(['GH_ADMIN_TOKEN', 'ADMIN_SLACK_TOKEN'])
+            EnvironmentVariables(['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'])
 
-    @patch.dict('os.environ', {'GH_ADMIN_TOKEN': 'fake_github_token', 'ADMIN_SLACK_TOKEN': 'fake_slack_token'})
+    @patch.dict('os.environ', {'GH_MOJ_TOKEN': 'fake_moj_github_token', 'GH_MOJAS_TOKEN': 'fake_mojas_github_token', 'ADMIN_SLACK_TOKEN': 'fake_slack_token'})
     def test_extra_env_vars(self):
         env_vars = EnvironmentVariables(
-            ['GH_ADMIN_TOKEN', 'ADMIN_SLACK_TOKEN', 'EXTRA_VAR'])
-        self.assertEqual(env_vars.get('GH_ADMIN_TOKEN'), 'fake_github_token')
+            ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN', 'EXTRA_VAR'])
+        self.assertEqual(env_vars.get('GH_MOJ_TOKEN'), 'fake_moj_github_token')
+        self.assertEqual(env_vars.get('GH_MOJAS_TOKEN'), 'fake_mojas_github_token')
         self.assertEqual(env_vars.get('ADMIN_SLACK_TOKEN'), 'fake_slack_token')
         self.assertIsNone(env_vars.get('EXTRA_VAR'))
 


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• To try to reduce the frequency of hitting the rate limiting by using a separate token per org. And to take this opportunity to ensure the tokens used adhere to POLP.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• ♻️ GH_ADMIN_TOKEN replaced with one token per org & tokens added to repo secrets
• 🧪 Updated corresponding tests
• ✨ These tokens are new FG-PATs with read only minimum privileges
• ♻️ Updated some print statements to `logging.info` and added `logging.info` to track requests 

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

• Multiple tokens do nothing for rate limiting - the rate limiting is per repo; POLPyness is improved though.

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)

- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
