### PR TITLE
Gha quota update

### DIFF
--- a/bin/fetch_github_actions_quota.py
+++ b/bin/fetch_github_actions_quota.py
@@ -17,11 +17,8 @@ def get_environment_variables() -> str:
 def fetch_gha_quota():
     github_token = get_environment_variables()
     github_service = GithubService(github_token, MINISTRY_OF_JUSTICE, ENTERPRISE)
-
-    # Get all organisations
-    organisations = github_service.get_all_organisations_in_enterprise()
-    # Get total quota usage
-    total_minutes_used = github_service.calculate_total_minutes_used(organisations)
+    
+    total_minutes_used = github_service.calculate_total_minutes_enterprise()
 
     # Save metric in KPI dashboard db
     KpiService(os.getenv("KPI_DASHBOARD_URL"), os.getenv("KPI_DASHBOARD_API_KEY")).track_enterprise_github_actions_quota_usage(total_minutes_used)

--- a/bin/fetch_github_actions_quota.py
+++ b/bin/fetch_github_actions_quota.py
@@ -17,7 +17,7 @@ def get_environment_variables() -> str:
 def fetch_gha_quota():
     github_token = get_environment_variables()
     github_service = GithubService(github_token, MINISTRY_OF_JUSTICE, ENTERPRISE)
-    
+
     total_minutes_used = github_service.calculate_total_minutes_enterprise()
 
     # Save metric in KPI dashboard db

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1107,9 +1107,9 @@ class GithubService:
             f"https://api.github.com/orgs/{organization}/settings/billing/actions", headers=headers)
 
         return response.json()
-     
-    def get_all_private_internal_repos_names(self, org_name:str):
-        
+
+    def get_all_private_internal_repos_names(self, org_name: str):
+
         logging.info(
             f"Getting all private and internal repos used for organization {org_name}")
         private_internal_repos = []
@@ -1119,10 +1119,10 @@ class GithubService:
             repo.visibility=="internal" or repo.visibility=="private")]
 
         return private_internal_repos
-    
+
     @retries_github_rate_limit_exception_at_next_reset_once
     def get_current_month_gha_minutes_for_enterprise(self, month) -> int:
-        
+
         logging.info(
             f"Getting usage report for current billing month for the enterprise {self.enterprise_name}")
 
@@ -1130,13 +1130,12 @@ class GithubService:
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28"
         }
-        
+
         response = self.github_client_rest_api.get(
             f"https://api.github.com/enterprises/{self.enterprise_name}/settings/billing/usage?month={month}", headers=headers)
 
         return response.json()
-    
-    
+
     @retries_github_rate_limit_exception_at_next_reset_once
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
@@ -1166,13 +1165,13 @@ class GithubService:
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def calculate_total_minutes_enterprise(self):
-        
+
         organisations = self.get_all_organisations_in_enterprise()
         enterprise_billable_repos=[]
         for org in organisations: 
             org_repos = self.get_all_private_internal_repos_names(org)
             enterprise_billable_repos.extend(org_repos)
-                
+
         gha_minutes_total = 0.0
         if enterprise_billable_repos:
             current_billing_month =  datetime.now().month
@@ -1184,12 +1183,12 @@ class GithubService:
                 and item.get('unitType') == 'Minutes'
                 and item.get('repositoryName') in enterprise_billable_repos
             )
-        
+
         return gha_minutes_total
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def check_if_gha_minutes_quota_is_low(self):
-       
+
         total_minutes_used = self.calculate_total_minutes_enterprise()
 
         print(f"Total minutes used: {total_minutes_used}")

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1168,7 +1168,7 @@ class GithubService:
 
         organisations = self.get_all_organisations_in_enterprise()
         enterprise_billable_repos = []
-        for org in organisations: 
+        for org in organisations:
             org_repos = self.get_all_private_internal_repos_names(org)
             enterprise_billable_repos.extend(org_repos)
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1115,8 +1115,9 @@ class GithubService:
         private_internal_repos = []
         org = self.github_client_core_api.get_organization(org_name)
         all_repos = org.get_repos(type="all")
-        private_internal_repos = [repo.name for repo in all_repos if not repo.archived and (
-            repo.visibility == "internal" or repo.visibility == "private")]
+        private_internal_repos = [
+            repo.name for repo in all_repos if not repo.archived and repo.visibility in (
+                'internal', 'private')]
 
         return private_internal_repos
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1107,7 +1107,36 @@ class GithubService:
             f"https://api.github.com/orgs/{organization}/settings/billing/actions", headers=headers)
 
         return response.json()
+     
+    def get_all_private_internal_repos_names(self, org_name:str):
+        
+        logging.info(
+            f"Getting all private and internal repos used for organization {org_name}")
+        private_internal_repos = []
+        org = self.github_client_core_api.get_organization(org_name)
+        all_repos = org.get_repos(type="all")
+        private_internal_repos = [repo.name for repo in all_repos if not repo.archived and (
+            repo.visibility=="internal" or repo.visibility=="private")]
 
+        return private_internal_repos
+    
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def get_current_month_gha_minutes_for_enterprise(self, month) -> int:
+        
+        logging.info(
+            f"Getting usage report for current billing month for the enterprise {self.enterprise_name}")
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+        
+        response = self.github_client_rest_api.get(
+            f"https://api.github.com/enterprises/{self.enterprise_name}/settings/billing/usage?month={month}", headers=headers)
+
+        return response.json()
+    
+    
     @retries_github_rate_limit_exception_at_next_reset_once
     def modify_gha_minutes_quota_threshold(self, new_threshold):
         logging.info(f"Changing the alerting threshold to {new_threshold}%")
@@ -1136,21 +1165,32 @@ class GithubService:
             self.modify_gha_minutes_quota_threshold(base_alerting_threshold)
 
     @retries_github_rate_limit_exception_at_next_reset_once
-    def calculate_total_minutes_used(self, organisations):
-        total = 0
-
-        for org in organisations:
-            billing_data = self.get_gha_minutes_used_for_organisation(org)
-            minutes_used = billing_data["total_minutes_used"]
-            total += minutes_used
-
-        return total
+    def calculate_total_minutes_enterprise(self):
+        
+        organisations = self.get_all_organisations_in_enterprise()
+        enterprise_billable_repos=[]
+        for org in organisations: 
+            org_repos = self.get_all_private_internal_repos_names(org)
+            enterprise_billable_repos.extend(org_repos)
+                
+        gha_minutes_total = 0.0
+        if enterprise_billable_repos:
+            current_billing_month =  datetime.now().month
+            billing_data = self.get_current_month_gha_minutes_for_enterprise(current_billing_month)
+            gha_minutes_total = sum(
+                item['quantity']
+                for item in billing_data.get('usageItems')
+                if item.get('product') == 'actions'
+                and item.get('unitType') == 'Minutes'
+                and item.get('repositoryName') in enterprise_billable_repos
+            )
+        
+        return gha_minutes_total
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def check_if_gha_minutes_quota_is_low(self):
-        organisations = self.get_all_organisations_in_enterprise()
-
-        total_minutes_used = self.calculate_total_minutes_used(organisations)
+       
+        total_minutes_used = self.calculate_total_minutes_enterprise()
 
         print(f"Total minutes used: {total_minutes_used}")
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1116,7 +1116,7 @@ class GithubService:
         org = self.github_client_core_api.get_organization(org_name)
         all_repos = org.get_repos(type="all")
         private_internal_repos = [repo.name for repo in all_repos if not repo.archived and (
-            repo.visibility=="internal" or repo.visibility=="private")]
+            repo.visibility == "internal" or repo.visibility == "private")]
 
         return private_internal_repos
 
@@ -1167,14 +1167,14 @@ class GithubService:
     def calculate_total_minutes_enterprise(self):
 
         organisations = self.get_all_organisations_in_enterprise()
-        enterprise_billable_repos=[]
+        enterprise_billable_repos = []
         for org in organisations: 
             org_repos = self.get_all_private_internal_repos_names(org)
             enterprise_billable_repos.extend(org_repos)
 
         gha_minutes_total = 0.0
         if enterprise_billable_repos:
-            current_billing_month =  datetime.now().month
+            current_billing_month = datetime.now().month
             billing_data = self.get_current_month_gha_minutes_for_enterprise(current_billing_month)
             gha_minutes_total = sum(
                 item['quantity']

--- a/test/test_bin/test_fetch_github_actions_quota.py
+++ b/test/test_bin/test_fetch_github_actions_quota.py
@@ -32,28 +32,24 @@ class TestFetchGithubActionsQuota(unittest.TestCase):
     @patch("gql.Client.__new__", new=MagicMock)
     @patch("github.Github.__new__", new=MagicMock)
     @patch("bin.fetch_github_actions_quota.get_environment_variables")
-    @patch.object(GithubService, "get_all_organisations_in_enterprise")
-    @patch.object(GithubService, "calculate_total_minutes_used")
+    @patch.object(GithubService, "calculate_total_minutes_enterprise")
     @patch.object(KpiService, "track_enterprise_github_actions_quota_usage")
     def test_fetch_gha_quota(
         self,
         mock_track_enterprise_github_actions_quota_usage,
-        mock_calculate_total_minutes_used,
-        mock_get_all_organisations_in_enterprise,
+        mock_calculate_total_minutes_enterprise,
         mock_get_environment_variables
     ):
         # Mock services
         mock_get_environment_variables.return_value = "token_mock"
-        mock_get_all_organisations_in_enterprise.return_value = ['org1', 'org2']
-        mock_calculate_total_minutes_used.return_value = 3456778
+        mock_calculate_total_minutes_enterprise.return_value = 3456778
 
         # Run script
         fetch_gha_quota()
 
         # Assert
         mock_get_environment_variables.assert_called_once()
-        mock_get_all_organisations_in_enterprise.assert_called_once()
-        mock_calculate_total_minutes_used.assert_called_once_with(['org1', 'org2'])
+        mock_calculate_total_minutes_enterprise.assert_called_once()
         mock_track_enterprise_github_actions_quota_usage.assert_called_once_with(3456778)
 
 

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1614,7 +1614,7 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
     def test_get_all_private_internal_repos_names(self,  _mock_github_client_rest_api, mock_github_client_core_api): 
 
-        def create_mock_repo(name: str, archived:bool, visibility: str, ):
+        def create_mock_repo(name: str, archived: bool, visibility: str, ):
             mock_repo = MagicMock()
             mock_repo.name = name
             mock_repo.visibility = visibility
@@ -1635,9 +1635,7 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         mock_org.get_repos.return_value = mock_repos
         repos = github_service.get_all_private_internal_repos_names("test_org")
 
-   
         self.assertEqual(repos, ["repo1", "repo2"])
-
 
     @patch.object(GithubService, "get_all_organisations_in_enterprise")
     @patch.object(GithubService, "get_all_private_internal_repos_names")
@@ -1659,17 +1657,17 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         mock_datetime.now.return_value = datetime(2025, 1, 29)
         mock_get_current_month_gha_minutes_for_enterprise.return_value = {
             "usageItems": [
-                { "date": "2025-01-06T15:15:47Z", "product": "actions",
+                {"date": "2025-01-06T15:15:47Z", "product": "actions",
                  "sku": "Actions Linux", "quantity": 100,
                  "unitType": "Minutes", "pricePerUnit": 0.008,
                  "grossAmount": 0.8, "discountAmount": 0, "netAmount": 0.8,
                  "organizationName": "test_org1", "repositoryName": "repo1"},
-                { "date": "'2025-01-06T15:18:44Z'", "product": "actions",
+                {"date": "'2025-01-06T15:18:44Z'", "product": "actions",
                  "sku": "Actions Linux", "quantity": 35,
                  "unitType": "Minutes", "pricePerUnit": 0.008,
                  "grossAmount": 0.8, "discountAmount": 0, "netAmount": 0.8,
                  "organizationName": "test_org1", "repositoryName": "repo2"},
-                { "date": "'2025-01-06T15:20:44Z'", "product": "actions",
+                {"date": "'2025-01-06T15:20:44Z'", "product": "actions",
                  "sku": "Actions Linux", "quantity": 50,
                  "unitType": "Minutes", "pricePerUnit": 0.008,
                  "grossAmount": 0.8, "discountAmount": 0, "netAmount": 0.8,

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1612,7 +1612,7 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
         assert not mock_modify_gha_minutes_quota_threshold.called
 
-    def test_get_all_private_internal_repos_names(self,  _mock_github_client_rest_api, mock_github_client_core_api): 
+    def test_get_all_private_internal_repos_names(self,  _mock_github_client_rest_api, mock_github_client_core_api):
 
         def create_mock_repo(name: str, archived: bool, visibility: str, ):
             mock_repo = MagicMock()
@@ -1651,8 +1651,8 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
 
         mock_get_all_organisations_in_enterprise.return_value = ['test_org1', 'test_org2']
         mock_repos = {
-        "test_org1": ["repo1", "repo2"],
-        "test_org2": ["repo3"]}
+            "test_org1": ["repo1", "repo2"],
+            "test_org2": ["repo3"]}
         mock_get_all_private_internal_repos_names.side_effect = lambda org: mock_repos[org]
         mock_datetime.now.return_value = datetime(2025, 1, 29)
         mock_get_current_month_gha_minutes_for_enterprise.return_value = {

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -1613,18 +1613,18 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         assert not mock_modify_gha_minutes_quota_threshold.called
 
     def test_get_all_private_internal_repos_names(self,  _mock_github_client_rest_api, mock_github_client_core_api): 
-        
-        def create_mock_repo(name:str, archived:bool, visibility:str, ):
+
+        def create_mock_repo(name: str, archived:bool, visibility: str, ):
             mock_repo = MagicMock()
-            mock_repo.name=name
-            mock_repo.visibility=visibility
+            mock_repo.name = name
+            mock_repo.visibility = visibility
             mock_repo.archived = archived
-            
+
             return mock_repo
-            
+
         github_service = GithubService("", ORGANISATION_NAME)
         mock_org = MagicMock()
-        
+
         mock_repos = [
             create_mock_repo(name="repo1", archived=False, visibility="internal"),
             create_mock_repo(name="repo2", archived=False, visibility="private"),
@@ -1634,8 +1634,8 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         mock_github_client_core_api.return_value.get_organization.return_value = mock_org
         mock_org.get_repos.return_value = mock_repos
         repos = github_service.get_all_private_internal_repos_names("test_org")
-        
-        
+
+   
         self.assertEqual(repos, ["repo1", "repo2"])
 
 
@@ -1657,7 +1657,7 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         "test_org2": ["repo3"]}
         mock_get_all_private_internal_repos_names.side_effect = lambda org: mock_repos[org]
         mock_datetime.now.return_value = datetime(2025, 1, 29)
-        mock_get_current_month_gha_minutes_for_enterprise.return_value ={
+        mock_get_current_month_gha_minutes_for_enterprise.return_value = {
             "usageItems": [
                 { "date": "2025-01-06T15:15:47Z", "product": "actions",
                  "sku": "Actions Linux", "quantity": 100,
@@ -1713,7 +1713,7 @@ class TestGHAMinutesQuotaOperations(unittest.TestCase):
         _mock_github_client_core_api
     ):
         github_service = GithubService("", ORGANISATION_NAME)
-        
+
         mock_calculate_total_minutes_enterprise.return_value = 5000
         mock_get_repository_variable.side_effect = self._mock_repository_variable
 


### PR DESCRIPTION
GitHub changed the way how the gha minutes quota can be retrieved for the enterprise. In the past the gha quota had to be retrieved per organization. Current Github API version allows to request Usage report, which gives usage data broken down by repository. 

Functional Requirements (What):

- [x] Updated operations-engineering/bin/fetch_github_actions_quota
- [x] Updated operations-engineering/bin/alert_on_low_gha_quota
- [x] Updated operations-engineering/services/github_service.py
- [x] Updated unit tests


<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

•[#5182](https://github.com/ministryofjustice/operations-engineering/issues/5182)

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)

- [x] I have run all unit tests, and they pass.
- [x] I have ensured my code follows the project's coding standards.
- [x] I have checked that all new dependencies are up to date and necessary.
