### PR TITLE
Identify dormant outside collaborators

### DIFF
--- a/.github/workflows/job-identify-dormant-github-users-v2.yml
+++ b/.github/workflows/job-identify-dormant-github-users-v2.yml
@@ -1,5 +1,4 @@
-# This workflow is triggered manually to identify dormant GitHub users. It's currently in an experimental phase and will eventually be integrated into the main dormant user process.
-name: 🧪 Identify Dormant GitHub Users
+name: ⚙️ Identify Dormant GitHub Users
 
 on:
   workflow_dispatch:

--- a/.github/workflows/job-identify-dormant-outside-collaborators.yml
+++ b/.github/workflows/job-identify-dormant-outside-collaborators.yml
@@ -1,6 +1,7 @@
 name: ⚙️ Identify Dormant Outside Collaborators
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       days_since:

--- a/.github/workflows/job-identify-dormant-outside-collaborators.yml
+++ b/.github/workflows/job-identify-dormant-outside-collaborators.yml
@@ -1,0 +1,46 @@
+name: ⚙️ Identify Dormant Outside Collaborators
+
+on:
+  workflow_dispatch:
+    inputs:
+      days_since:
+        type: choice
+        description: "Select the number of days since to check for outside collaborator dormancy."
+        options:
+          - "90"
+          - "60"
+          - "30"
+        default: "90"
+
+jobs:
+  identify_dormant_outside_collaborators:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.11"
+          cache: "pipenv"
+
+      - name: Install Pipenv
+        run: |
+          pip install pipenv
+          pipenv install
+
+      - name: Identify Dormant Outside Collaborators
+        run: pipenv run python3 -m bin.identify_dormant_outside_collaborators
+        env:
+          GH_MOJ_TOKEN: ${{ secrets.GH_MOJ_DORMANT_USERS_READ }}
+          GH_MOJAS_TOKEN: ${{ secrets.GH_MOJAS_DORMANT_USERS_READ }}
+          ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
+          DAYS_SINCE: ${{ inputs.days_since }}
+
+      # - name: Report failure to Slack
+      #   if: always()
+      #   uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/job-identify-dormant-outside-collaborators.yml
+++ b/.github/workflows/job-identify-dormant-outside-collaborators.yml
@@ -40,7 +40,3 @@ jobs:
           GH_MOJAS_TOKEN: ${{ secrets.GH_MOJAS_DORMANT_USERS_READ }}
           ADMIN_SLACK_TOKEN: ${{ secrets.ADMIN_SEND_TO_SLACK }}
           DAYS_SINCE: ${{ inputs.days_since }}
-
-      # - name: Report failure to Slack
-      #   if: always()
-      #   uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/job-identify-dormant-outside-collaborators.yml
+++ b/.github/workflows/job-identify-dormant-outside-collaborators.yml
@@ -1,7 +1,6 @@
 name: ⚙️ Identify Dormant Outside Collaborators
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       days_since:

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import time
+from github import GithubException
+from config.constants import MINISTRY_OF_JUSTICE, MOJ_ANALYTICAL_SERVICES
+
+from services.github_service import GithubService
+from services.slack_service import SlackService
+from utils.environment import EnvironmentVariables
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def identify_dormant_outside_collaborators():
+    env = EnvironmentVariables(["GH_MOJ_TOKEN", "GH_MOJAS_TOKEN", "ADMIN_SLACK_TOKEN", "DAYS_SINCE"])
+    days_since = int(env.get("DAYS_SINCE"))
+
+    gh_orgs = [
+        GithubService(env.get("GH_MOJ_TOKEN"), MINISTRY_OF_JUSTICE),
+        GithubService(env.get("GH_MOJAS_TOKEN"), MOJ_ANALYTICAL_SERVICES)
+    ]
+
+    for gh_org in gh_orgs:
+        dormant_outside_collaborators = gh_org.get_dormant_outside_collaborators()
+
+        SlackService(env.get("ADMIN_SLACK_TOKEN")).send_dormant_user_list(dormant_outside_collaborators, str(days_since))
+
+
+if __name__ == "__main__":
+    start = time.time()
+    identify_dormant_outside_collaborators()
+    end = time.time()
+    print(f"\nTime taken: {(end-start) / 60} minutes")
+
+# #  This currently removes dormant OCs -  just want it to identify and post to slack, also post failure to slack
+# def get_environment_variables() -> str:
+#     github_token = os.getenv("ADMIN_GITHUB_TOKEN")
+#     if not github_token:
+#         raise ValueError(
+#             "The env variable ADMIN_GITHUB_TOKEN is empty or missing")
+
+#     github_organization_name = os.getenv("GITHUB_ORGANIZATION_NAME")
+#     if not github_organization_name:
+#         raise ValueError(
+#             "The env variable GITHUB_ORGANIZATION_NAME is empty or missing")
+
+#     return github_token, github_organization_name
+
+
+# def main():
+#     github_token, github_organization_name = get_environment_variables()
+#     github = GithubService(github_token, github_organization_name)
+#     dormant_outside_collaborators = github.get_dormant_outside_collaborators()
+
+#     if not dormant_outside_collaborators:
+#         logger.info(
+#             "No Dormant Outside Collaborators detected."
+#         )
+
+#     for dormant_outside_collaborator in dormant_outside_collaborators:
+#         try:
+#             github.remove_outside_collaborator_from_org(dormant_outside_collaborator)
+#             logger.info(
+#                 "Removed Outside Collaborator %s from %s",
+#                 dormant_outside_collaborator,
+#                 github_organization_name
+#             )
+#         except GithubException:
+#             logger.error(
+#                 "Failed to remove Outside Collaborator %s from %s",
+#                 dormant_outside_collaborator,
+#                 github_organization_name
+#             )
+
+
+# if __name__ == "__main__":
+#     main()

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -22,11 +22,13 @@ def identify_dormant_outside_collaborators():
         GithubService(env.get("GH_MOJ_TOKEN"), MINISTRY_OF_JUSTICE),
         GithubService(env.get("GH_MOJAS_TOKEN"), MOJ_ANALYTICAL_SERVICES)
     ]
-
+    print("Starting OC run")
     ocs_repos_and_activity = []
     for gh_org in gh_orgs:
+        print(f"Getting repos and OCs for {gh_org.organisation_name}")
         active_repos_and_outside_collaborators = gh_org.get_active_repos_and_outside_collaborators()
         for repo_object in active_repos_and_outside_collaborators:
+            logging.info("Checking Outside Collaborator activity for %s", repo_object.get('repository'))
             for oc in repo_object.get("outside_collaborators"):
                 is_oc_active_in_repo = gh_org.user_has_committed_to_repo_since(
                     username=oc,

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -24,7 +24,7 @@ def identify_dormant_outside_collaborators():
     ]
     ocs_repos_and_activity = []
     for gh_org in gh_orgs:
-        logging.info("Getting repos and Outside Collaborators for %s", gh_org.organisation_name)
+        logging.info("Getting repositories and Outside Collaborators for %s", gh_org.organisation_name)
         active_repos_and_outside_collaborators = gh_org.get_active_repos_and_outside_collaborators()
         for repo_object in active_repos_and_outside_collaborators:
             logging.info("Checking Outside Collaborator activity for %s", repo_object.get('repository'))

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -26,8 +26,11 @@ def identify_dormant_outside_collaborators():
     for gh_org in gh_orgs:
         logging.info("Getting repositories and Outside Collaborators for %s", gh_org.organisation_name)
         active_repos_and_outside_collaborators = gh_org.get_active_repos_and_outside_collaborators()
+        repo_count = 1
+        number_of_repos = len(active_repos_and_outside_collaborators)
         for repo_object in active_repos_and_outside_collaborators:
-            logging.info("Checking Outside Collaborator activity for %s", repo_object.get('repository'))
+            logging.info("Checking Outside Collaborator activity for repository %s of %s", repo_count, number_of_repos)
+            repo_count += 1
             for oc in repo_object.get("outside_collaborators"):
                 is_oc_active_in_repo = gh_org.user_has_committed_to_repo_since(
                     username=oc,
@@ -46,7 +49,7 @@ def identify_dormant_outside_collaborators():
 
     df_oc_report = pd.DataFrame(ocs_repos_and_activity)
     # Get commit activity for each OC: summing T/F means no commits in any repo shows as 0
-    activity_pivot = df_oc_report.pivot_table(['active'], 'outside_collaborator', aggfunc=sum)
+    activity_pivot = df_oc_report.pivot_table(['active'], 'outside_collaborator', aggfunc='sum')
     # Filter for zero commits
     ocs_with_zero_commits = activity_pivot.loc[activity_pivot["active"] == 0]
 

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -47,10 +47,10 @@ def identify_dormant_outside_collaborators():
     # Get commit activity for each OC: summing T/F means no commits in any repo shows as 0
     activity_pivot = df_oc_report.pivot_table(['active'], 'outside_collaborator', aggfunc=sum)
     # Filter for zero commits
-    zero_commits = activity_pivot.loc[activity_pivot["active"] == 0]
+    ocs_with_zero_commits = activity_pivot.loc[activity_pivot["active"] == 0]
 
     SlackService(env.get("ADMIN_SLACK_TOKEN")).send_dormant_outside_collaborator_list(
-        user_list=zero_commits.index.values,
+        user_list=ocs_with_zero_commits.index.values,
         days_since=str(days_since)
     )
 

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -29,9 +29,9 @@ def identify_dormant_outside_collaborators():
         for repo_object in active_repos_and_outside_collaborators:
             for oc in repo_object.get("outside_collaborators"):
                 is_oc_active_in_repo = gh_org.user_has_committed_to_repo_since(
-                    username = oc,
-                    repo_name = repo_object.get("repository"),
-                    since_datetime = since_datetime
+                    username=oc,
+                    repo_name=repo_object.get("repository"),
+                    since_datetime=since_datetime
                 )
                 ocs_repos_and_activity.append(
                     {
@@ -53,8 +53,6 @@ def identify_dormant_outside_collaborators():
         user_list=zero_commits.index.values,
         days_since=str(days_since)
     )
-
-    return None
 
 if __name__ == "__main__":
     start = time.time()

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -22,10 +22,9 @@ def identify_dormant_outside_collaborators():
         GithubService(env.get("GH_MOJ_TOKEN"), MINISTRY_OF_JUSTICE),
         GithubService(env.get("GH_MOJAS_TOKEN"), MOJ_ANALYTICAL_SERVICES)
     ]
-    print("Starting OC run")
     ocs_repos_and_activity = []
     for gh_org in gh_orgs:
-        print(f"Getting repos and OCs for {gh_org.organisation_name}")
+        logging.info("Getting repos and Outside Collaborators for %s", gh_org.organisation_name)
         active_repos_and_outside_collaborators = gh_org.get_active_repos_and_outside_collaborators()
         for repo_object in active_repos_and_outside_collaborators:
             logging.info("Checking Outside Collaborator activity for %s", repo_object.get('repository'))

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -54,6 +54,7 @@ def identify_dormant_outside_collaborators():
         days_since=str(days_since)
     )
 
+
 if __name__ == "__main__":
     start = time.time()
     identify_dormant_outside_collaborators()

--- a/bin/identify_dormant_outside_collaborators.py
+++ b/bin/identify_dormant_outside_collaborators.py
@@ -51,7 +51,7 @@ def identify_dormant_outside_collaborators():
     ocs_with_zero_commits = activity_pivot.loc[activity_pivot["active"] == 0]
 
     SlackService(env.get("ADMIN_SLACK_TOKEN")).send_dormant_outside_collaborator_list(
-        user_list=ocs_with_zero_commits.index.values,
+        user_list=ocs_with_zero_commits.index.values.tolist(),
         days_since=str(days_since)
     )
 

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -534,10 +534,11 @@ class GithubService:
                         raise ValueError(
                             f"Repo has more than {self.GITHUB_GQL_MAX_PAGE_SIZE} Outside Collaborators; only collected the first {self.GITHUB_GQL_MAX_PAGE_SIZE} hence omitted and calculation unreliable."
                         )
+                    public = False
                     if repo["visibility"] == "PUBLIC":
                         public = True
-                    else:
-                        public = False
+                    # else:
+                    #     public = False
                     if repo["collaborators"]["edges"]:
                         collaborators = [edge["node"]["login"] for edge in repo["collaborators"]["edges"]]
                         active_repos_and_outside_collaborators.append(

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -548,12 +548,9 @@ class GithubService:
 
         return active_repos_and_outside_collaborators
 
-
-
     @retries_github_rate_limit_exception_at_next_reset_once
     def fetch_all_repositories_in_org(self) -> list[dict[str, Any]]:
         """A wrapper function to run a GraphQL query to get the list of repositories in the organisation
-
         Returns:
             list: A list of the organisation repos names
         """
@@ -1393,7 +1390,6 @@ class GithubService:
         ]
         return repos
 
-
     @retries_github_rate_limit_exception_at_next_reset_once
     def user_has_committed_to_repo_since(
         self,
@@ -1410,7 +1406,6 @@ class GithubService:
         if commits.totalCount > 0:
             return True
         return False
-
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def user_has_commmits_since(

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -93,7 +93,7 @@ class GithubService:
         logging.info("Getting Outside Collaborators Login Names")
         outside_collaborators = self.github_client_core_api.get_organization(
             self.organisation_name).get_outside_collaborators() or []
-        return [outside_collaborator.login.lower() for outside_collaborator in outside_collaborators]
+        return outside_collaborators
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def add_all_users_to_team(self, team_name: str) -> None:
@@ -169,47 +169,6 @@ class GithubService:
                                 name
                             }
                         }
-                    }
-                }
-            }
-        """), variable_values={"organisation_name": self.organisation_name, "page_size": page_size,
-                               "after_cursor": after_cursor})
-
-    @retries_github_rate_limit_exception_at_next_reset_once
-    def get_paginated_list_of_unlocked_unarchived_repos_and_their_first_100_outside_collaborators(
-        self,
-        after_cursor: str | None,
-        page_size: int = GITHUB_GQL_DEFAULT_PAGE_SIZE,
-    ) -> dict[str, Any]:
-        logging.info(
-            f"Getting paginated list of org unlocked unarchived repositories and their first 100 outside collaborators. Page size {page_size}, after cursor {bool(after_cursor)}"
-        )
-        if page_size > self.GITHUB_GQL_MAX_PAGE_SIZE:
-            raise ValueError(
-                f"Page size of {page_size} is too large. Max page size {self.GITHUB_GQL_MAX_PAGE_SIZE}")
-        return self.github_client_gql_api.execute(gql("""
-            query($organisation_name: String!, $page_size: Int!, $after_cursor: String) {
-                organization(login: $organisation_name) {
-                    repositories(first: $page_size, after: $after_cursor, isLocked: false, isArchived: false) {
-                        pageInfo {
-                            endCursor
-                            hasNextPage
-                        }
-                        nodes {
-                            name
-                            isDisabled
-                            collaborators(first: 100, affiliation: OUTSIDE){
-                                pageInfo {
-                                    hasNextPage
-                                }
-                                edges {
-                                    node {
-                                        login
-                                    }
-                                }
-                            }
-                        }
-
                     }
                 }
             }
@@ -500,21 +459,67 @@ class GithubService:
             "after_cursor": after_cursor
         })
 
-    def get_dormant_outside_collaborators(self) -> list[str]:
-        """A wrapper function to run a GraphQL query to get a list of the Dormant Outside Collaborators
-        in the organisation. These are Outside Collaborators not affiliated with any open (not locked,
-        not archived nor disabled) repositories. The function collects the Active Outside Collaborators
-        (those affiliated with at least one open repository) and then subtracts these from the total
-        list of Outside Collaborators.
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def get_paginated_list_of_unlocked_unarchived_repos_and_their_first_100_outside_collaborators(
+        self,
+        after_cursor: str | None,
+        page_size: int = GITHUB_GQL_DEFAULT_PAGE_SIZE,
+    ) -> dict[str, Any]:
+        logging.info(
+            f"Getting paginated list of org unlocked unarchived repositories and their first 100 outside collaborators. Page size {page_size}, after cursor {bool(after_cursor)}"
+        )
+        if page_size > self.GITHUB_GQL_MAX_PAGE_SIZE:
+            raise ValueError(
+                f"Page size of {page_size} is too large. Max page size {self.GITHUB_GQL_MAX_PAGE_SIZE}")
+        return self.github_client_gql_api.execute(gql("""
+            query($organisation_name: String!, $page_size: Int!, $after_cursor: String) {
+                organization(login: $organisation_name) {
+                    repositories(first: $page_size, after: $after_cursor, isLocked: false, isArchived: false) {
+                        pageInfo {
+                            endCursor
+                            hasNextPage
+                        }
+                        nodes {
+                            name
+                            isDisabled
+                            visibility
+                            collaborators(first: 100, affiliation: OUTSIDE){
+                                pageInfo {
+                                    hasNextPage
+                                }
+                                edges {
+                                    node {
+                                        login
+                                    }
+                                }
+                            }
+                        }
 
-        Returns:
-            list: A list of the organisation dormant outside collaborators login names in lower case
+                    }
+                }
+            }
+        """), variable_values={"organisation_name": self.organisation_name, "page_size": page_size,
+                               "after_cursor": after_cursor})
+
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def get_active_repos_and_outside_collaborators(self) -> list[dict[str, bool, list[str]]]:
+        """A wrapper function to run a GraphQL query to get a list of dictionaries containing active
+        repositories and for each its set of current affiliated Outside Collaborators login names for
+        the organisaiton. These Outside Collaborators are affiliated with at least one active (not locked,
+        archived nor disabled) repository.
+
+        Output:
+            list: A list of dictionaries containing active repositories and for each its list of current
+            affiliated outside collaborators login names. Also includes whether the repo has public
+            visibility or not (False = private or internal)
+            [
+                {'repository': 'repo1', 'public': True, 'outside_collaborators': ['c1', 'c2', 'c3']},
+                {'repository': 'repo2', 'public': False, 'outside_collaborators': ['c3', 'c4']}
+            ]
         """
-
-        all_outside_collaborators = self.get_outside_collaborators_login_names()
         repo_has_next_page = True
         after_cursor = None
-        active_outside_collaborators = []
+        active_repos_and_outside_collaborators = []
         while repo_has_next_page:
             data = self.get_paginated_list_of_unlocked_unarchived_repos_and_their_first_100_outside_collaborators(
                 after_cursor, self.GITHUB_GQL_MAX_PAGE_SIZE
@@ -524,21 +529,26 @@ class GithubService:
                     if repo["isDisabled"]:
                         continue
                     # The query only returns the first 100 Outside Collaborators on a repo, if there is a next page
-                    # it will not collect them. This is very unlikely to occur, however the function output is
-                    # unreliable if it does so.
+                    # of collaborators it will not collect them. This is very unlikely to occur, however the function
+                    # output is unreliable if it does so.
                     if repo["collaborators"]["pageInfo"]["hasNextPage"]:
                         raise ValueError(
-                            "Some Outside Collaborators omitted from calculation; cannot get reliable Dormant Outside Collaborators list."
+                            f"Repo has more than {self.GITHUB_GQL_MAX_PAGE_SIZE} Outside Collaborators; only collected the first {self.GITHUB_GQL_MAX_PAGE_SIZE} hence omitted and calculation unreliable."
                         )
-                    for collaborators in repo["collaborators"]["edges"]:
-                        if collaborators:
-                            active_outside_collaborators.append(collaborators["node"]["login"].lower())
+                    if repo["visibility"] == "PUBLIC":
+                        public = True
+                    else:
+                        public = False
+                    if repo["collaborators"]["edges"]:
+                        collaborators = [edge["node"]["login"] for edge in repo["collaborators"]["edges"]]
+                        active_repos_and_outside_collaborators.append(
+                            {"repository": repo["name"], "public": public, "outside_collaborators": collaborators}
+                        )
             repo_has_next_page = data["organization"]["repositories"]["pageInfo"]["hasNextPage"]
             after_cursor = data["organization"]["repositories"]["pageInfo"]["endCursor"]
 
-        dormant_outside_collaborators = set(all_outside_collaborators) - set(active_outside_collaborators)
+        return active_repos_and_outside_collaborators
 
-        return list(dormant_outside_collaborators)
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def fetch_all_repositories_in_org(self) -> list[dict[str, Any]]:
@@ -774,15 +784,6 @@ class GithubService:
         github_user = self.github_client_core_api.get_user(user)
         self.github_client_core_api.get_organization(
             self.organisation_name).remove_from_membership(github_user)
-
-    @retries_github_rate_limit_exception_at_next_reset_once
-    def remove_outside_collaborator_from_org(self, outside_collaborator: str):
-        github_user = self.github_client_core_api.get_user(outside_collaborator)
-        self.github_client_core_api.get_organization(
-            self.organisation_name
-        ).remove_outside_collaborator(
-            github_user
-        )
 
     def get_inactive_users(self, team_name: str, users_to_ignore, repositories_to_ignore: list[str],
                            inactivity_months: int) -> list[NamedUser.NamedUser]:

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -7,7 +7,6 @@ from time import gmtime, sleep
 from typing import Any, Callable
 import concurrent.futures
 
-
 from dateutil.relativedelta import relativedelta
 from github import (Github, NamedUser, RateLimitExceededException,
                     UnknownObjectException, GithubException)
@@ -548,6 +547,7 @@ class GithubService:
             after_cursor = data["organization"]["repositories"]["pageInfo"]["endCursor"]
 
         return active_repos_and_outside_collaborators
+
 
 
     @retries_github_rate_limit_exception_at_next_reset_once
@@ -1392,6 +1392,25 @@ class GithubService:
             repo_object.get("repository") for repo_object in repos_and_contributors if username in repo_object.get("contributors")
         ]
         return repos
+
+
+    @retries_github_rate_limit_exception_at_next_reset_once
+    def user_has_committed_to_repo_since(
+        self,
+        username: str,
+        repo_name: str,
+        since_datetime: datetime
+    ) -> bool:
+
+        repo = self.github_client_core_api.get_repo(f"{self.organisation_name}/{repo_name}")
+        commits = repo.get_commits(
+                since=since_datetime,
+                author=username.lower()
+        )
+        if commits.totalCount > 0:
+            return True
+        return False
+
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def user_has_commmits_since(

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -500,15 +500,15 @@ class GithubService:
             "after_cursor": after_cursor
         })
 
-    def get_stale_outside_collaborators(self) -> list[str]:
-        """A wrapper function to run a GraphQL query to get a list of the Stale Outside Collaborators
+    def get_dormant_outside_collaborators(self) -> list[str]:
+        """A wrapper function to run a GraphQL query to get a list of the Dormant Outside Collaborators
         in the organisation. These are Outside Collaborators not affiliated with any open (not locked,
         not archived nor disabled) repositories. The function collects the Active Outside Collaborators
         (those affiliated with at least one open repository) and then subtracts these from the total
         list of Outside Collaborators.
 
         Returns:
-            list: A list of the organisation stale outside collaborators login names in lower case
+            list: A list of the organisation dormant outside collaborators login names in lower case
         """
 
         all_outside_collaborators = self.get_outside_collaborators_login_names()
@@ -528,7 +528,7 @@ class GithubService:
                     # unreliable if it does so.
                     if repo["collaborators"]["pageInfo"]["hasNextPage"]:
                         raise ValueError(
-                            "Some Outside Collaborators omitted from calculation; cannot get reliable Stale Outside Collaborators list."
+                            "Some Outside Collaborators omitted from calculation; cannot get reliable Dormant Outside Collaborators list."
                         )
                     for collaborators in repo["collaborators"]["edges"]:
                         if collaborators:
@@ -536,9 +536,9 @@ class GithubService:
             repo_has_next_page = data["organization"]["repositories"]["pageInfo"]["hasNextPage"]
             after_cursor = data["organization"]["repositories"]["pageInfo"]["endCursor"]
 
-        stale_outside_collaborators = set(all_outside_collaborators) - set(active_outside_collaborators)
+        dormant_outside_collaborators = set(all_outside_collaborators) - set(active_outside_collaborators)
 
-        return list(stale_outside_collaborators)
+        return list(dormant_outside_collaborators)
 
     @retries_github_rate_limit_exception_at_next_reset_once
     def fetch_all_repositories_in_org(self) -> list[dict[str, Any]]:

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -537,8 +537,6 @@ class GithubService:
                     public = False
                     if repo["visibility"] == "PUBLIC":
                         public = True
-                    # else:
-                    #     public = False
                     if repo["collaborators"]["edges"]:
                         collaborators = [edge["node"]["login"] for edge in repo["collaborators"]["edges"]]
                         active_repos_and_outside_collaborators.append(

--- a/services/slack_service.py
+++ b/services/slack_service.py
@@ -103,7 +103,7 @@ class SlackService:
 
     def send_dormant_outside_collaborator_list(self, user_list, days_since: str):
         message = (
-            f"*Dormant Outside Collaborator Report*\n\n"
+            f"🦥*Dormant Outside Collaborator Report*🦥\n\n"
             f"These GitHub Outside Collaborators have made no commits for {days_since} days on any repository they are affiliated with:\n"
             f"{user_list}"
         )

--- a/services/slack_service.py
+++ b/services/slack_service.py
@@ -101,6 +101,15 @@ class SlackService:
         blocks = self._create_block_with_message(message)
         self._send_alert_to_operations_engineering(blocks)
 
+    def send_dormant_outside_collaborator_list(self, user_list, days_since: str):
+        message = (
+            f"*Dormant Outside Collaborator Report*\n\n"
+            f"These GitHub Outside Collaborators have made no commits for {days_since} days on any repository they are affiliated with:\n"
+            f"{user_list}"
+        )
+        blocks = self._create_block_with_message(message)
+        self._send_alert_to_operations_engineering(blocks)
+
     def send_pat_report_alert(self):
         message = (
             "*Expired PAT Report*\n\n"

--- a/services/slack_service.py
+++ b/services/slack_service.py
@@ -103,7 +103,7 @@ class SlackService:
 
     def send_dormant_outside_collaborator_list(self, user_list, days_since: str):
         message = (
-            f"🦥*Dormant Outside Collaborator Report*🦥\n\n"
+            f"🦥 *Dormant Outside Collaborator Report* 🦥\n\n"
             f"These GitHub Outside Collaborators have made no commits for {days_since} days on any repository they are affiliated with:\n"
             f"{user_list}"
         )

--- a/test/test_bin/test_identify_dormant_outside_collaborators.py
+++ b/test/test_bin/test_identify_dormant_outside_collaborators.py
@@ -1,41 +1,30 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from bin.identify_dormant_github_users_v2 import ALLOWED_BOT_USERS, get_inactive_users_from_data_lake_ignoring_bots_and_collaborators, identify_dormant_github_users
+from bin.identify_dormant_outside_collaborators import identify_dormant_outside_collaborators
 
-from services.cloudtrail_service import CloudtrailService
 
-class TestDormantOutsideCollaboratorsitHubUsers(unittest.TestCase):
-
-    def setUp(self):
-        self.allowed_bot_users = ALLOWED_BOT_USERS
-
-    @patch.object(CloudtrailService, "get_active_users_for_dormant_users_process")
-    def test_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(self, mock_get_active_users_for_dormant_users_process):
-        mock_get_active_users_for_dormant_users_process.return_value = ["member1"]
-        mock_github_service = MagicMock()
-        mock_github_service.get_all_enterprise_members = MagicMock(return_value=["member1", "member2", "analytical-platform-bot", "cloud-platform-dummy-user"])
-
-        assert get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(mock_github_service, self.allowed_bot_users, 90) == ["member2"]
+class TestIdentifyDormantOutsideCollaborators(unittest.TestCase):
 
     @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
     @patch("gql.Client.__new__", new=MagicMock)
     @patch("services.github_service.Github")
-    @patch('bin.identify_dormant_github_users_v2.filter_out_inactive_committers')
-    @patch('bin.identify_dormant_github_users_v2.filter_out_active_auth0_users')
-    @patch('bin.identify_dormant_github_users_v2.map_usernames_to_emails')
-    @patch('bin.identify_dormant_github_users_v2.get_inactive_users_from_data_lake_ignoring_bots_and_collaborators')
     @patch('os.environ')
-    def test_identify_dormant_github_users(self, mock_env, _mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators, mock_map_usernames_to_emails, mock_filter_out_active_auth0_users, mock_filter_out_inactive_committers, _mock_github_client_core_api):
+    def test_identify_dormant_outside_collaborators(self, mock_env, mock_get_active_repos_and_outside_collaborators, mock_user_has_committed_to_repo_since):
         mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
-        mock_map_usernames_to_emails.return_value = [{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}]
-        mock_filter_out_active_auth0_users.return_value = ["user1", "user2"]
+        mock_get_active_repos_and_outside_collaborators.return_value = [
+            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1', 'outside_collab_2']},
+            {'repository': 'repo2', 'public': True, 'outside_collaborators': ['outside_collab_3']}
+        ]
+        mock_user_has_committed_to_repo_since.return_value =
+        # mock_map_usernames_to_emails.return_value = [{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}]
+        # mock_filter_out_active_auth0_users.return_value = ["user1", "user2"]
 
-        identify_dormant_github_users()
+        identify_dormant_outside_collaborators()
 
-        mock_map_usernames_to_emails.assert_called_once()
-        mock_filter_out_active_auth0_users.assert_called_once_with([{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}], 90)
-        mock_filter_out_inactive_committers.assert_called_once()
+        # mock_map_usernames_to_emails.assert_called_once()
+        # mock_filter_out_active_auth0_users.assert_called_once_with([{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}], 90)
+        # mock_filter_out_inactive_committers.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/test_bin/test_identify_dormant_outside_collaborators.py
+++ b/test/test_bin/test_identify_dormant_outside_collaborators.py
@@ -8,18 +8,28 @@ from services.slack_service import SlackService
 
 class TestIdentifyDormantOutsideCollaborators(unittest.TestCase):
 
+    def setUp(self):
+        self.test_data_for_both_orgs = [
+            [
+                {'repository': 'repo1', 'public': False, 'outside_collaborators': ['oc1']},
+                {'repository': 'repo2', 'public': False, 'outside_collaborators': ['oc1', 'oc2']}
+            ],
+            [
+                {'repository': 'repo3', 'public': False, 'outside_collaborators': ['oc2']},
+
+            ]
+        ]
+
     @patch.object(GithubService, "__new__")
     @patch.object(SlackService, "__new__")
     @patch('os.environ')
-    def test_identify_non_active_outside_collaborators(self, mock_env, mock_slack_service, mock_github_service):
+    def test_all_outside_collaborators_dormant(self, mock_env, mock_slack_service, mock_github_service):
         mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
 
         mock_github_instance = MagicMock()
         mock_github_service.return_value = mock_github_instance
-        mock_github_instance.get_active_repos_and_outside_collaborators.return_value = [
-            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1']}
-        ]
-        mock_github_instance.user_has_committed_to_repo_since.return_value = False
+        mock_github_instance.get_active_repos_and_outside_collaborators.side_effect = self.test_data_for_both_orgs
+        mock_github_instance.user_has_committed_to_repo_since.side_effect = [False, False, False, False]
 
         mock_slack_instance = MagicMock()
         mock_slack_service.return_value = mock_slack_instance
@@ -27,20 +37,56 @@ class TestIdentifyDormantOutsideCollaborators(unittest.TestCase):
         identify_dormant_outside_collaborators()
 
         mock_slack_instance.send_dormant_outside_collaborator_list.assert_called()
-        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called_once_with(user_list=['outside_collab_1'], days_since='90')
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called_once_with(user_list=['oc1', 'oc2'], days_since='90')
 
     @patch.object(GithubService, "__new__")
     @patch.object(SlackService, "__new__")
     @patch('os.environ')
-    def test_ignore_active_outside_collaborators(self, mock_env, mock_slack_service, mock_github_service):
+    def test_one_outside_collaborator_dormant(self, mock_env, mock_slack_service, mock_github_service):
         mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
 
         mock_github_instance = MagicMock()
         mock_github_service.return_value = mock_github_instance
-        mock_github_instance.get_active_repos_and_outside_collaborators.return_value = [
-            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1']}
-        ]
-        mock_github_instance.user_has_committed_to_repo_since.return_value = True
+        mock_github_instance.get_active_repos_and_outside_collaborators.side_effect = self.test_data_for_both_orgs
+        mock_github_instance.user_has_committed_to_repo_since.side_effect = [False, True, False, False]
+
+        mock_slack_instance = MagicMock()
+        mock_slack_service.return_value = mock_slack_instance
+
+        identify_dormant_outside_collaborators()
+
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called()
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called_once_with(user_list=['oc2'], days_since='90')
+
+    @patch.object(GithubService, "__new__")
+    @patch.object(SlackService, "__new__")
+    @patch('os.environ')
+    def test_active_in_all_repos_identifies_zero_dormant_ocs(self, mock_env, mock_slack_service, mock_github_service):
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
+
+        mock_github_instance = MagicMock()
+        mock_github_service.return_value = mock_github_instance
+        mock_github_instance.get_active_repos_and_outside_collaborators.side_effect = self.test_data_for_both_orgs
+        mock_github_instance.user_has_committed_to_repo_since.side_effect = [True, True, True, True]
+
+        mock_slack_instance = MagicMock()
+        mock_slack_service.return_value = mock_slack_instance
+
+        identify_dormant_outside_collaborators()
+
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called()
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called_once_with(user_list=[], days_since='90')
+
+    @patch.object(GithubService, "__new__")
+    @patch.object(SlackService, "__new__")
+    @patch('os.environ')
+    def test_ocs_active_in_at_least_one_repo_identifies_zero_dormant_ocs(self, mock_env, mock_slack_service, mock_github_service):
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
+
+        mock_github_instance = MagicMock()
+        mock_github_service.return_value = mock_github_instance
+        mock_github_instance.get_active_repos_and_outside_collaborators.side_effect = self.test_data_for_both_orgs
+        mock_github_instance.user_has_committed_to_repo_since.side_effect = [False, True, True, False]
 
         mock_slack_instance = MagicMock()
         mock_slack_service.return_value = mock_slack_instance

--- a/test/test_bin/test_identify_dormant_outside_collaborators.py
+++ b/test/test_bin/test_identify_dormant_outside_collaborators.py
@@ -16,15 +16,11 @@ class TestIdentifyDormantOutsideCollaborators(unittest.TestCase):
             {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1', 'outside_collab_2']},
             {'repository': 'repo2', 'public': True, 'outside_collaborators': ['outside_collab_3']}
         ]
-        mock_user_has_committed_to_repo_since.return_value =
-        # mock_map_usernames_to_emails.return_value = [{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}]
-        # mock_filter_out_active_auth0_users.return_value = ["user1", "user2"]
+        mock_user_has_committed_to_repo_since.return_value = [True, False, True]
 
         identify_dormant_outside_collaborators()
 
-        # mock_map_usernames_to_emails.assert_called_once()
-        # mock_filter_out_active_auth0_users.assert_called_once_with([{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}], 90)
-        # mock_filter_out_inactive_committers.assert_called_once()
+        mock_get_active_repos_and_outside_collaborators.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/test_bin/test_identify_dormant_outside_collaborators.py
+++ b/test/test_bin/test_identify_dormant_outside_collaborators.py
@@ -3,24 +3,52 @@ from unittest.mock import MagicMock, patch
 
 from bin.identify_dormant_outside_collaborators import identify_dormant_outside_collaborators
 
+from services.github_service import GithubService
+from services.slack_service import SlackService
 
 class TestIdentifyDormantOutsideCollaborators(unittest.TestCase):
 
-    @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
-    @patch("gql.Client.__new__", new=MagicMock)
-    @patch("services.github_service.Github")
+    @patch.object(GithubService, "__new__")
+    @patch.object(SlackService, "__new__")
     @patch('os.environ')
-    def test_identify_dormant_outside_collaborators(self, mock_env, mock_get_active_repos_and_outside_collaborators, mock_user_has_committed_to_repo_since):
+    def test_identify_non_active_outside_collaborators(self, mock_env, mock_slack_service, mock_github_service):
         mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
-        mock_get_active_repos_and_outside_collaborators.return_value = [
-            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1', 'outside_collab_2']},
-            {'repository': 'repo2', 'public': True, 'outside_collaborators': ['outside_collab_3']}
+
+        mock_github_instance = MagicMock()
+        mock_github_service.return_value = mock_github_instance
+        mock_github_instance.get_active_repos_and_outside_collaborators.return_value = [
+            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1']}
         ]
-        mock_user_has_committed_to_repo_since.return_value = [True, False, True]
+        mock_github_instance.user_has_committed_to_repo_since.return_value = False
+
+        mock_slack_instance = MagicMock()
+        mock_slack_service.return_value = mock_slack_instance
 
         identify_dormant_outside_collaborators()
 
-        mock_get_active_repos_and_outside_collaborators.assert_called_once()
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called()
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called_once_with(user_list=['outside_collab_1'], days_since='90')
+
+    @patch.object(GithubService, "__new__")
+    @patch.object(SlackService, "__new__")
+    @patch('os.environ')
+    def test_ignore_active_outside_collaborators(self, mock_env, mock_slack_service, mock_github_service):
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
+
+        mock_github_instance = MagicMock()
+        mock_github_service.return_value = mock_github_instance
+        mock_github_instance.get_active_repos_and_outside_collaborators.return_value = [
+            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1']}
+        ]
+        mock_github_instance.user_has_committed_to_repo_since.return_value = True
+
+        mock_slack_instance = MagicMock()
+        mock_slack_service.return_value = mock_slack_instance
+
+        identify_dormant_outside_collaborators()
+
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called()
+        mock_slack_instance.send_dormant_outside_collaborator_list.assert_called_once_with(user_list=[], days_since='90')
 
 
 if __name__ == "__main__":

--- a/test/test_bin/test_identify_dormant_outside_collaborators.py
+++ b/test/test_bin/test_identify_dormant_outside_collaborators.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from bin.identify_dormant_github_users_v2 import ALLOWED_BOT_USERS, get_inactive_users_from_data_lake_ignoring_bots_and_collaborators, identify_dormant_github_users
+
+from services.cloudtrail_service import CloudtrailService
+
+class TestDormantOutsideCollaboratorsitHubUsers(unittest.TestCase):
+
+    def setUp(self):
+        self.allowed_bot_users = ALLOWED_BOT_USERS
+
+    @patch.object(CloudtrailService, "get_active_users_for_dormant_users_process")
+    def test_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(self, mock_get_active_users_for_dormant_users_process):
+        mock_get_active_users_for_dormant_users_process.return_value = ["member1"]
+        mock_github_service = MagicMock()
+        mock_github_service.get_all_enterprise_members = MagicMock(return_value=["member1", "member2", "analytical-platform-bot", "cloud-platform-dummy-user"])
+
+        assert get_inactive_users_from_data_lake_ignoring_bots_and_collaborators(mock_github_service, self.allowed_bot_users, 90) == ["member2"]
+
+    @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+    @patch("gql.Client.__new__", new=MagicMock)
+    @patch("services.github_service.Github")
+    @patch('bin.identify_dormant_github_users_v2.filter_out_inactive_committers')
+    @patch('bin.identify_dormant_github_users_v2.filter_out_active_auth0_users')
+    @patch('bin.identify_dormant_github_users_v2.map_usernames_to_emails')
+    @patch('bin.identify_dormant_github_users_v2.get_inactive_users_from_data_lake_ignoring_bots_and_collaborators')
+    @patch('os.environ')
+    def test_identify_dormant_github_users(self, mock_env, _mock_get_inactive_users_from_data_lake_ignoring_bots_and_collaborators, mock_map_usernames_to_emails, mock_filter_out_active_auth0_users, mock_filter_out_inactive_committers, _mock_github_client_core_api):
+        mock_env.get.side_effect = lambda k: 'mock_token' if k in ['GH_MOJ_TOKEN', 'GH_MOJAS_TOKEN', 'ADMIN_SLACK_TOKEN'] else 90 if k in ['DAYS_SINCE'] else None
+        mock_map_usernames_to_emails.return_value = [{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}]
+        mock_filter_out_active_auth0_users.return_value = ["user1", "user2"]
+
+        identify_dormant_github_users()
+
+        mock_map_usernames_to_emails.assert_called_once()
+        mock_filter_out_active_auth0_users.assert_called_once_with([{"name": "user1", "email": "user1@gmail.com"}, {"name": "user2", "email": "user1@gmail.com"}, {"name": "user3", "email": "user1@gmail.com"}], 90)
+        mock_filter_out_inactive_committers.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -707,7 +707,7 @@ class TestGithubServiceGetOrgRepoNames(unittest.TestCase):
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__", new=MagicMock)
-class TestGithubServiceGetStaleOutsideCollaborators(unittest.TestCase):
+class TestGithubServiceGetDormantOutsideCollaborators(unittest.TestCase):
     def setUp(self):
         self.return_data = {
             "organization": {
@@ -770,9 +770,9 @@ class TestGithubServiceGetStaleOutsideCollaborators(unittest.TestCase):
         github_service.get_outside_collaborators_login_names = MagicMock(
             return_value=self.all_outside_collaborators
         )
-        stale_outside_collaborators = github_service.get_stale_outside_collaborators()
-        self.assertEqual(len(stale_outside_collaborators), 1)
-        self.assertEqual(stale_outside_collaborators, ["outside_collab_4"])
+        dormant_outside_collaborators = github_service.get_dormant_outside_collaborators()
+        self.assertEqual(len(dormant_outside_collaborators), 1)
+        self.assertEqual(dormant_outside_collaborators, ["outside_collab_4"])
 
     def test_counts_disabled_repo_outside_collaborators(self):
         github_service = GithubService("", ORGANISATION_NAME)
@@ -783,9 +783,9 @@ class TestGithubServiceGetStaleOutsideCollaborators(unittest.TestCase):
         github_service.get_outside_collaborators_login_names = MagicMock(
             return_value=self.all_outside_collaborators
         )
-        stale_outside_collaborators = github_service.get_stale_outside_collaborators()
-        self.assertEqual(len(stale_outside_collaborators), 2)
-        self.assertEqual(set(stale_outside_collaborators), set(["outside_collab_3", "outside_collab_4"]))
+        dormant_outside_collaborators = github_service.get_dormant_outside_collaborators()
+        self.assertEqual(len(dormant_outside_collaborators), 2)
+        self.assertEqual(set(dormant_outside_collaborators), set(["outside_collab_3", "outside_collab_4"]))
 
     def test_outside_collaborators_has_next_page_raises_error(self):
         github_service = GithubService("", ORGANISATION_NAME)
@@ -797,7 +797,7 @@ class TestGithubServiceGetStaleOutsideCollaborators(unittest.TestCase):
             return_value=self.all_outside_collaborators
         )
         with self.assertRaises(ValueError):
-            github_service.get_stale_outside_collaborators()
+            github_service.get_dormant_outside_collaborators()
 
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -790,7 +790,8 @@ class TestGithubServiceGetActiveReposAndOutsideCollaborators(unittest.TestCase):
         )
         active_repos_and_ocs = github_service.get_active_repos_and_outside_collaborators()
         response = [
-            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1', 'outside_collab_2']}        ]
+            {'repository': 'repo1', 'public': False, 'outside_collaborators': ['outside_collab_1', 'outside_collab_2']}
+        ]
         self.assertEqual(len(active_repos_and_ocs), 1)
         self.assertEqual(active_repos_and_ocs, response)
 

--- a/test/test_services/test_github_service.py
+++ b/test/test_services/test_github_service.py
@@ -2083,6 +2083,40 @@ class TestGithubServiceUserHasCommitsSince(unittest.TestCase):
 
 @patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
 @patch("gql.Client.__new__", new=MagicMock)
+@patch("github.Github.__new__")
+class TestGithubServiceUserHasCommitedToRepoSince(unittest.TestCase):
+    def setUp(self):
+        self.since_datetime = datetime(2024, 5, 3)
+
+    def test_user_has_committed_to_repo_since_true(self, mock_github_client_core_api):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        mock_github_client_core_api.return_value.get_repo.side_effect = [
+            MagicMock(get_commits=MagicMock(return_value=MagicMock(totalCount=10)))
+        ]
+        response = github_service.user_has_committed_to_repo_since(
+            username="c1",
+            repo_name="repo1",
+            since_datetime=self.since_datetime
+        )
+        self.assertEqual(response, True)
+
+    def test_user_has_committed_to_repo_since_false(self, mock_github_client_core_api):
+        github_service = GithubService("", ORGANISATION_NAME)
+
+        mock_github_client_core_api.return_value.get_repo.side_effect = [
+            MagicMock(get_commits=MagicMock(return_value=MagicMock(totalCount=0)))
+        ]
+        response = github_service.user_has_committed_to_repo_since(
+            username="c1",
+            repo_name="repo1",
+            since_datetime=self.since_datetime
+        )
+        self.assertEqual(response, False)
+
+
+@patch("gql.transport.aiohttp.AIOHTTPTransport.__new__", new=MagicMock)
+@patch("gql.Client.__new__", new=MagicMock)
 @patch("github.Github.__new__", new=MagicMock)
 class TestGithubServiceGetPaginatedListOfUnlockedUnarchivedRepos(unittest.TestCase):
     def test_calls_downstream_services(self):

--- a/test/test_services/test_slack_service.py
+++ b/test/test_services/test_slack_service.py
@@ -259,6 +259,20 @@ class TestSlackService(unittest.TestCase):
             channel="C033QBE511V", mrkdown=True, blocks=blocks
         )
 
+    def test_send_dormant_outside_collaborator_list(self):
+        user_list = "Test user list"
+        days_since = "13"
+        expected_message = (
+            f"🦥 *Dormant Outside Collaborator Report* 🦥\n\n"
+            f"These GitHub Outside Collaborators have made no commits for {days_since} days on any repository they are affiliated with:\n"
+            f"{user_list}"
+        )
+        blocks = self.slack_service._create_block_with_message(expected_message)
+        self.slack_service.send_dormant_outside_collaborator_list(user_list, str(13))
+        self.mock_slack_client.return_value.chat_postMessage.assert_called_once_with(
+            channel="C033QBE511V", mrkdown=True, blocks=blocks
+        )
+
     def test_send_pat_report_alert(self):
         expected_message = (
             "*Expired PAT Report*\n\n"


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
<!-- markdownlint-disable MD041 -->
## :eyes: Purpose

• To be able to track dormant Outside Collaborators in both MoJ GH Orgs and identify those who have made no commits to any repo they are affiliated with since the given datetime.

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

• ✨ Identify dormant outside collaborators identifies OCs who have made no commits to any repo they are affiliated with
• ♻️ Removed experimental ref in Identify Dormant GitHub users
• ✨ New Slack message re Dormant OCs and tests
• ♻️ Rejig GQL collaborators code to return repo visibility info as well
• ✨ 🧪 New tests

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

• We are most concerned with recovering GH licences and as a back stop for ex-OCs; this new workflow defines dormant OCs as those who have made no commits to any repo they are affiliated with since the given datetime. People with read only access are therefore considered dormant.

---
<!-- Optionally, check you've completed the following actions before submitting the PR -->
### :white_check_mark: Things to Check (Optional)

- [x] I have run all unit tests, and they pass.
- [ ] I have ensured my code follows the project's coding standards.
- [ ] I have checked that all new dependencies are up to date and necessary.
